### PR TITLE
Add `CropOptions`

### DIFF
--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -247,7 +247,7 @@ fn ui(f: &mut Frame<'_>, app: &mut App) {
     match app.show_images {
         ShowImages::Fixed => {}
         _ => {
-            let image = StatefulImage::new(None).resize(Resize::Crop);
+            let image = StatefulImage::new(None).resize(Resize::Crop(None));
             f.render_stateful_widget(
                 image,
                 block_left_bottom.inner(chunks_left_bottom[0]),


### PR DESCRIPTION
This allows the user to decide which side of the image should be cropped when resizing to fit the containing `Rect`. This is a breaking change, and let me know if the API is okay. I could swap the boolean `clip_bottom` and `clip_right` values with enums, if you want!

I could also work on an example, if necessary. I tested it the project I need it for and it works, but if you want something more robust I can definitely work on that.