### PR TITLE
semver hazards: use ^ instead of >=

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,12 +112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,7 +1267,7 @@ dependencies = [
 name = "ratatui-image"
 version = "1.0.5"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "crossterm",
  "dyn-clone",
  "icy_sixel",
@@ -1732,7 +1726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a75313e21da5d4406ea31402035b3b97aa74c04356bdfafa5d1043ab4e551d1"
 dependencies = [
  "anyhow",
- "base64 0.21.2",
+ "base64",
  "bitflags 2.3.3",
  "fancy-regex",
  "filedescriptor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,17 +25,17 @@ serde = ["dep:serde"]
 rustix = ["dep:rustix"]
 
 [dependencies]
-dyn-clone = "1.0.11"
-image = { version = ">=0.24", default-features = false, features = ["jpeg"] }
-icy_sixel = { version = "0.1.1" }
-crossterm = { version = ">=0.25", optional = true }
-termion = { version = ">=2.0", optional = true }
-termwiz = { version = ">=0.20", optional = true }
+dyn-clone = "^1.0.11"
+image = { version = "^0.25.1", default-features = false, features = ["jpeg"] }
+icy_sixel = { version = "^0.1.1" }
+crossterm = { version = "^0.27.0", optional = true }
+termion = { version = "^3.0.0", optional = true }
+termwiz = { version = "^0.22.0", optional = true }
 serde = { version = "^1.0", optional = true, features = ["derive"] }
 rustix = { version = "^0.38.4", optional = true, features = ["stdio", "termios", "fs"] }
-base64 = { version = "^0.22.1" }
-rand = { version = "0.8.5" }
-ratatui = { version = ">=0.23", default-features = false, features = [] }
+base64 = { version = "^0.21.2" }
+rand = { version = "^0.8.5" }
+ratatui = { version = "^0.26.2", default-features = false, features = [] }
 
 [[bin]]
 name = "ratatui-image"


### PR DESCRIPTION
Closes #35 - more details in that issue.

In general this should make ratatui-image be more flexible to pick the same version as dependant or sibling dependencies.