### PR TITLE
Fix kitty protocol within tmux, and improve its handling

### DIFF
--- a/src/picker.rs
+++ b/src/picker.rs
@@ -26,7 +26,7 @@ pub struct Picker {
     pub background_color: Option<Rgb<u8>>,
     pub protocol_type: ProtocolType,
     pub is_tmux: bool,
-    kitty_counter: u8,
+    kitty_counter: u32,
 }
 
 /// Serde-friendly protocol-type enum for [Picker].
@@ -95,7 +95,7 @@ impl Picker {
             background_color: None,
             protocol_type: ProtocolType::Halfblocks,
             is_tmux: false,
-            kitty_counter: 0,
+            kitty_counter: rand::random(),
         }
     }
 
@@ -138,7 +138,7 @@ impl Picker {
                 size,
             )?)),
             ProtocolType::Kitty => {
-                self.kitty_counter = self.kitty_counter.saturating_add(1);
+                self.kitty_counter = self.kitty_counter.checked_add(1).unwrap_or(1);
                 Ok(Box::new(Kitty::from_source(
                     &source,
                     resize,
@@ -164,7 +164,7 @@ impl Picker {
             ProtocolType::Halfblocks => Box::new(StatefulHalfblocks::new(source)),
             ProtocolType::Sixel => Box::new(StatefulSixel::new(source, self.is_tmux)),
             ProtocolType::Kitty => {
-                self.kitty_counter = self.kitty_counter.saturating_add(1);
+                self.kitty_counter = self.kitty_counter.checked_add(1).unwrap_or(1);
                 Box::new(StatefulKitty::new(source, self.kitty_counter))
             }
             ProtocolType::Iterm2 => Box::new(Iterm2State::new(source, self.is_tmux)),

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -145,6 +145,7 @@ impl Picker {
                     self.background_color,
                     size,
                     self.kitty_counter,
+                    self.is_tmux,
                 )?))
             }
             ProtocolType::Iterm2 => Ok(Box::new(FixedIterm2::from_source(
@@ -165,7 +166,7 @@ impl Picker {
             ProtocolType::Sixel => Box::new(StatefulSixel::new(source, self.is_tmux)),
             ProtocolType::Kitty => {
                 self.kitty_counter = self.kitty_counter.checked_add(1).unwrap_or(1);
-                Box::new(StatefulKitty::new(source, self.kitty_counter))
+                Box::new(StatefulKitty::new(source, self.kitty_counter, self.is_tmux))
             }
             ProtocolType::Iterm2 => Box::new(Iterm2State::new(source, self.is_tmux)),
         }

--- a/src/protocol/kitty.rs
+++ b/src/protocol/kitty.rs
@@ -183,11 +183,11 @@ fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool) -> String {
             }
             n if n + 1 == chunk_count => {
                 // m=0 means over
-                str.push_str(&format!("_Gq=2,i={id},m=0;{payload}"));
+                str.push_str(&format!("_Gq=2,m=0;{payload}"));
             }
             _ => {
                 // Keep adding chunks
-                str.push_str(&format!("_Gq=2,i={id},m=1;{payload}"));
+                str.push_str(&format!("_Gq=2,m=1;{payload}"));
             }
         }
         if is_tmux {

--- a/src/protocol/kitty.rs
+++ b/src/protocol/kitty.rs
@@ -1,5 +1,5 @@
 /// https://sw.kovidgoyal.net/kitty/graphics-protocol/#unicode-placeholders
-use std::format;
+use std::fmt::Write;
 
 use base64::{engine::general_purpose, Engine};
 use image::{DynamicImage, Rgb};
@@ -178,17 +178,19 @@ fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool) -> String {
             0 => {
                 // Transmit and virtual-place but keep sending chunks
                 let more = if chunk_count > 1 { 1 } else { 0 };
-                str.push_str(&format!(
+                write!(
+                    str,
                     "_Gq=2,i={id},a=T,U=1,f=24,t=d,s={w},v={h},m={more};{payload}"
-                ));
+                )
+                .unwrap();
             }
             n if n + 1 == chunk_count => {
                 // m=0 means over
-                str.push_str(&format!("_Gq=2,m=0;{payload}"));
+                write!(str, "_Gq=2,m=0;{payload}").unwrap();
             }
             _ => {
                 // Keep adding chunks
-                str.push_str(&format!("_Gq=2,m=1;{payload}"));
+                write!(str, "_Gq=2,m=1;{payload}").unwrap();
             }
         }
         if is_tmux {

--- a/src/protocol/kitty.rs
+++ b/src/protocol/kitty.rs
@@ -160,11 +160,11 @@ fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool) -> String {
 
     let mut str = String::new();
 
-    let mut payload: String;
-    let chunks = bytes.chunks(4000);
+    // Max chunk size is 4096 bytes of base64 encoded data
+    let chunks = bytes.chunks(4096 / 4 * 3);
     let chunk_count = chunks.len();
     for (i, chunk) in chunks.enumerate() {
-        payload = general_purpose::STANDARD.encode(chunk);
+        let payload = general_purpose::STANDARD.encode(chunk);
         // tmux seems to only allow a limited amount of data in each passthrough sequence, since
         // we're already chunking the data for the kitty protocol that's a good enough chunk size to
         // use for the passthrough chunks too

--- a/src/protocol/kitty.rs
+++ b/src/protocol/kitty.rs
@@ -138,7 +138,8 @@ fn render(area: Rect, rect: Rect, buf: &mut Buffer, id: u32, seq: &mut Option<St
 
         for x in 1..(area.width.min(rect.width)) {
             // Add entire row with positions
-            add_placeholder(&mut symbol, x, y, id_extra);
+            // Use inherited diacritic values
+            symbol.push('\u{10EEEE}');
             // Skip or something may overwrite it
             buf.get_mut(area.left() + x, area.top() + y).set_skip(true);
         }


### PR DESCRIPTION
I can split this up if needed, but there's a few overlapping changes that lead to conflicts so I thought it was easier to put into one PR.

The first commit (probabilistically) avoids issues with having multiple applications rendering images, previously they were almost guaranteed to use overlapping ids since they all started from 1 and only had 255 ids available. Now the full `u32` support from the protocol is used with a random starting point so it's unlikely to overlap.

The second commit fixes #22, the kitty-protocol escape sequences are now wrapped in tmux-passthrough escapes if needed.

The third and fourth fix issues I noticed while debugging issues and reading the spec.

The fifth and sixth are minor performance improvements.