### PR TITLE
font size from CSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let backend = TestBackend::new(80, 30);
     let mut terminal = Terminal::new(backend)?;
 
-    // Should use Picker::from_termios(), to get the font size,
+    // Should use Picker::from_query_stdio() to get the font size and protocol,
     // but we can't put that here because that would break doctests!
     let mut picker = Picker::new((8, 12));
-    // Guess the protocol.
-    picker.guess_protocol();
 
     // Load an image with the image crate.
     let dyn_img = image::io::Reader::open("./assets/Ada.png")?.decode()?;

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Should use Picker::from_query_stdio() to get the font size and protocol,
     // but we can't put that here because that would break doctests!
-    let mut picker = Picker::new((8, 12));
+    let mut picker = Picker::from_fontsize((8, 12));
 
     // Load an image with the image crate.
     let dyn_img = image::io::Reader::open("./assets/Ada.png")?.decode()?;

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -5,7 +5,6 @@ use std::{
     time::Duration,
 };
 
-use image::Rgb;
 use ratatui::{
     backend::CrosstermBackend,
     crossterm::{
@@ -42,8 +41,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut terminal = Terminal::new(backend)?;
 
     let mut picker = Picker::from_query_stdio()?;
-    picker.query_stdio();
-    picker.background_color = Some(Rgb::<u8>([255, 0, 255]));
     let dyn_img = image::io::Reader::open("./assets/Ada.png")?.decode()?;
 
     // Send a [ResizeProtocol] to resize and encode it in a separate thread.

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -41,8 +41,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut picker = Picker::from_termios()?;
-    picker.guess_protocol();
+    let mut picker = Picker::from_query_stdio()?;
+    picker.query_stdio();
     picker.background_color = Some(Rgb::<u8>([255, 0, 255]));
     let dyn_img = image::io::Reader::open("./assets/Ada.png")?.decode()?;
 

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -80,7 +80,7 @@ impl<'a> App<'a> {
             .new_protocol(dyn_img.clone(), size(), Resize::Fit(None))
             .unwrap();
 
-        let image_source = ImageSource::new(dyn_img.clone(), picker.font_size);
+        let image_source = ImageSource::new(dyn_img.clone(), picker.font_size());
         let image_fit_state = picker.new_resize_protocol(dyn_img.clone());
         let image_crop_state = picker.new_resize_protocol(dyn_img);
 
@@ -133,7 +133,8 @@ impl<'a> App<'a> {
                 }
             }
             'i' => {
-                self.picker.cycle_protocols();
+                self.picker
+                    .set_protocol_type(self.picker.protocol_type().next());
                 self.reset_images();
             }
             'o' => {
@@ -142,7 +143,7 @@ impl<'a> App<'a> {
                     _ => "./assets/Ada.png",
                 };
                 let dyn_img = image::io::Reader::open(path).unwrap().decode().unwrap();
-                self.image_source = ImageSource::new(dyn_img.clone(), self.picker.font_size);
+                self.image_source = ImageSource::new(dyn_img.clone(), self.picker.font_size());
                 self.image_source_path = path.into();
                 self.reset_images();
             }
@@ -292,11 +293,11 @@ fn ui(f: &mut Frame<'_>, app: &mut App) {
             Line::from("H/L: resize"),
             Line::from(format!(
                 "i: cycle image protocols (current: {:?})",
-                app.picker.protocol_type
+                app.picker.protocol_type()
             )),
             Line::from("o: cycle image"),
             Line::from(format!("t: toggle ({:?})", app.show_images)),
-            Line::from(format!("Font size: {:?}", app.picker.font_size)),
+            Line::from(format!("Font size: {:?}", app.picker.font_size())),
         ])
         .wrap(Wrap { trim: true }),
         area,

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -74,8 +74,8 @@ impl<'a> App<'a> {
         let ada = "./assets/Ada.png";
         let dyn_img = image::io::Reader::open(ada).unwrap().decode().unwrap();
 
-        let mut picker = Picker::from_termios().unwrap();
-        picker.guess_protocol();
+        let mut picker = Picker::from_query_stdio().unwrap();
+        picker.query_stdio();
 
         let image_static = picker
             .new_protocol(dyn_img.clone(), size(), Resize::Fit(None))

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -75,7 +75,6 @@ impl<'a> App<'a> {
         let dyn_img = image::io::Reader::open(ada).unwrap().decode().unwrap();
 
         let mut picker = Picker::from_query_stdio().unwrap();
-        picker.query_stdio();
 
         let image_static = picker
             .new_protocol(dyn_img.clone(), size(), Resize::Fit(None))

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -3,6 +3,7 @@ use std::{
     process::{Command, Stdio},
 };
 
+use image::Rgb;
 use ratatui::{
     backend::CrosstermBackend,
     crossterm::{
@@ -36,6 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut terminal = Terminal::new(backend)?;
 
     let mut picker = Picker::from_query_stdio()?;
+    picker.set_background_color(Some(Rgb::<u8>([255, 0, 255])));
     if false {
         assert_eq!(
             ASSERT_FONT_SIZE,

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -3,7 +3,6 @@ use std::{
     process::{Command, Stdio},
 };
 
-use image::Rgb;
 use ratatui::{
     backend::CrosstermBackend,
     crossterm::{
@@ -37,11 +36,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut terminal = Terminal::new(backend)?;
 
     let mut picker = Picker::from_query_stdio()?;
-    picker.query_stdio();
-    picker.background_color = Some(Rgb::<u8>([255, 0, 255]));
     if false {
         assert_eq!(
-            ASSERT_FONT_SIZE, picker.font_size,
+            ASSERT_FONT_SIZE,
+            picker.font_size(),
             "Font size must be fixed to a specific size: {ASSERT_FONT_SIZE:?}",
         );
     }

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -36,8 +36,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut picker = Picker::from_termios()?;
-    picker.guess_protocol();
+    let mut picker = Picker::from_query_stdio()?;
+    picker.query_stdio();
     picker.background_color = Some(Rgb::<u8>([255, 0, 255]));
     if false {
         assert_eq!(

--- a/src/bin/ratatui-image/main.rs
+++ b/src/bin/ratatui-image/main.rs
@@ -42,13 +42,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = image::io::Reader::open(&filename)?.decode()?;
 
     #[cfg(all(feature = "rustix", unix))]
-    let mut picker = Picker::from_termios()?;
+    let mut picker = Picker::from_query_stdio()?;
     #[cfg(not(all(feature = "rustix", unix)))]
     let mut picker = {
         let font_size = (8, 16);
         Picker::new(font_size)
     };
-    picker.guess_protocol();
+    picker.query_stdio();
     picker.background_color = Some(Rgb::<u8>([255, 0, 255]));
 
     let image_source = ImageSource::new(image.clone(), picker.font_size);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //!     // Should use Picker::from_query_stdio() to get the font size and protocol,
 //!     // but we can't put that here because that would break doctests!
-//!     let mut picker = Picker::new((8, 12));
+//!     let mut picker = Picker::from_fontsize((8, 12));
 //!
 //!     // Load an image with the image crate.
 //!     let dyn_img = image::io::Reader::open("./assets/Ada.png")?.decode()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,9 @@
 //!     let backend = TestBackend::new(80, 30);
 //!     let mut terminal = Terminal::new(backend)?;
 //!
-//!     // Should use Picker::from_termios(), to get the font size,
+//!     // Should use Picker::from_query_stdio() to get the font size and protocol,
 //!     // but we can't put that here because that would break doctests!
 //!     let mut picker = Picker::new((8, 12));
-//!     // Guess the protocol.
-//!     picker.guess_protocol();
 //!
 //!     // Load an image with the image crate.
 //!     let dyn_img = image::io::Reader::open("./assets/Ada.png")?.decode()?;

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -141,6 +141,10 @@ impl Picker {
         self.font_size
     }
 
+    pub fn set_background_color(&mut self, background_color: Option<Rgb<u8>>) {
+        self.background_color = background_color
+    }
+
     /// Returns a new protocol for [`crate::Image`] widgets that fits into the given size.
     pub fn new_protocol(
         &mut self,


### PR DESCRIPTION
* Get font size (cell size) from CSI sequence `[16t`
* Still use `tcgetwinsize` as fallback
* Parsing has "current sequence" state to improve resilience against possible bad input
* Rely on `[5n` status query stop reading from stdin
* Remove complicated non-blocking & timeout reading from stdin
* Reorganize `Picker` public API
* stdin reading is isolated to a single function, for a future windows implementation
* General env var magic guessing improvements and cleanup