### PR TITLE
build with rustix on windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           args: ci-all
       - name: Build a windows binary
         if: matrix.platform == 'windows-latest'
-        run: cargo build --bin ratatui-image --no-default-features --features crossterm,image-defaults
+        run: cargo build --bin ratatui-image --features crossterm
 
   ensure-readme:
     name: Ensure readme is up-to-date


### PR DESCRIPTION
Can we replace the rustix::io::read/write to stdin with std::io::read/write? Is it possible to set canonical mode, echo mode, and (not sure if necessary) drain option, just with std::io?