### PR TITLE
feat: make query_stdio_capabilities work for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,7 @@ dependencies = [
  "ratatui",
  "rustix",
  "serde",
+ "windows",
 ]
 
 [[package]]
@@ -2081,6 +2082,70 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,23 +16,24 @@ exclude = [
 rust-version = "1.74.0"
 
 [features]
-default = ["image-defaults", "rustix"]
+default = ["image-defaults"]
 crossterm = ["ratatui/crossterm"]
 image-defaults = ["image/default"]
 termion = ["ratatui/termion"]
 termwiz = ["ratatui/termwiz"]
 serde = ["dep:serde"]
-rustix = ["dep:rustix"]
 
 [dependencies]
 dyn-clone = "^1.0.11"
 image = { version = "^0.25.1", default-features = false, features = ["jpeg"] }
 icy_sixel = { version = "^0.1.1" }
 serde = { version = "^1.0", optional = true, features = ["derive"] }
-rustix = { version = "^0.38.4", optional = true, features = ["stdio", "termios", "fs"] }
 base64 = { version = "^0.21.2" }
 rand = { version = "^0.8.5" }
 ratatui = { version = "^0.28.1", default-features = false, features = [] }
+
+[target.'cfg(not(windows))'.dependencies]
+rustix = { version = "^0.38.4", features = ["stdio", "termios", "fs"] }
 
 [[bin]]
 name = "ratatui-image"
@@ -46,11 +47,11 @@ doc-scrape-examples = true
 
 [[example]]
 name = "screenshot"
-required-features = ["crossterm", "rustix"]
+required-features = ["crossterm"]
 
 [[example]]
 name = "async"
-required-features = ["crossterm", "rustix"]
+required-features = ["crossterm"]
 
 [package.metadata.docs.rs]
 features = ["crossterm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,14 @@ ratatui = { version = "^0.28.1", default-features = false, features = [] }
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "^0.38.4", features = ["stdio", "termios", "fs"] }
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58.0", default-features = false, features = [
+  "std",
+  "Win32_System_Console",
+  "Win32_Storage_FileSystem",
+  "Win32_Security",
+] }
+
 [[bin]]
 name = "ratatui-image"
 path = "./src/bin/ratatui-image/main.rs" # cargo readme needs this for some reason

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -56,11 +56,11 @@ args = ["build", "--features", "${BACKEND}"]
 [tasks.run-example]
 command = "cargo"
 args = [
-  "run", 
-  "--release", 
-  "--example", 
+  "run",
+  "--release",
+  "--example",
   "demo",
-  "--features", "rustix,serde,crossterm",
+  "--features", "serde,crossterm",
 ]
 
 # Screenshot tests
@@ -71,7 +71,7 @@ args = [
   "build",
   "--example",
   "screenshot",
-  "--features", "rustix,crossterm",
+  "--features", "crossterm",
 ]
 
 [tasks.screenshot-xvfb]
@@ -119,4 +119,3 @@ args = [
   "save",
   "target/recording.gif",
 ]
-

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ a desired columns+rows bound, and so on.
 The lib also includes a binary that renders an image file, but it is focused on testing.
 
 ## Features
-* `rustix` (default) enables much better guessing of graphics protocols with `rustix::termios::tcgetattr`.
 * `crossterm` or `termion` should match your ratatui backend. `termwiz` is available, but not
   working correctly with ratatu-image.
 * `serde` for `#[derive]`s on [picker::ProtocolType] for convenience, because it might be

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -4,8 +4,6 @@
     not(feature = "termwiz")
 ))]
 compile_error!("The demo needs one of the crossterm, termion, or termwiz features");
-#[cfg(not(feature = "rustix"))]
-compile_error!("The demo needs rustix until window_size is on ratataui");
 
 #[cfg(feature = "crossterm")]
 mod crossterm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 //! The lib also includes a binary that renders an image file, but it is focused on testing.
 //!
 //! # Features
-//! * `rustix` (default) enables much better guessing of graphics protocols with `rustix::termios::tcgetattr`.
 //! * `crossterm` or `termion` should match your ratatui backend. `termwiz` is available, but not
 //!   working correctly with ratatu-image.
 //! * `serde` for `#[derive]`s on [picker::ProtocolType] for convenience, because it might be

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -265,19 +265,16 @@ fn iterm2_from_env() -> Option<ProtocolType> {
 }
 
 #[cfg(not(windows))]
-static TERMINAL_MODE_PRIOR_RAW_MODE: std::sync::Mutex<Option<rustix::termios::Termios>> =
+static ORIGINAL_IN_MODE: std::sync::Mutex<Option<rustix::termios::Termios>> =
     std::sync::Mutex::new(None);
 
 #[cfg(not(windows))]
 fn enable_raw_mode() -> Result<()> {
     use rustix::termios::{self, LocalModes, OptionalActions};
 
-    let stdin = std::io::stdin();
+    let stdin = io::stdin();
     let mut termios = termios::tcgetattr(&stdin)?;
-    TERMINAL_MODE_PRIOR_RAW_MODE
-        .lock()
-        .unwrap()
-        .replace(termios.clone());
+    *ORIGINAL_IN_MODE.lock().unwrap() = Some(termios.clone());
 
     // Disable canonical mode to read without waiting for Enter, disable echoing.
     termios.local_modes &= !LocalModes::ICANON;
@@ -291,8 +288,8 @@ fn enable_raw_mode() -> Result<()> {
 fn disable_raw_mode() -> Result<()> {
     use rustix::termios::{self, OptionalActions};
 
-    if let Some(termios) = TERMINAL_MODE_PRIOR_RAW_MODE.lock().unwrap().as_ref() {
-        termios::tcsetattr(std::io::stdin(), OptionalActions::Now, termios)?;
+    if let Some(termios) = ORIGINAL_IN_MODE.lock().unwrap().as_ref() {
+        termios::tcsetattr(io::stdin(), OptionalActions::Now, termios)?;
     }
 
     Ok(())

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -256,7 +256,7 @@ static TERMINAL_MODE_PRIOR_RAW_MODE: std::sync::Mutex<Option<rustix::termios::Te
     std::sync::Mutex::new(None);
 
 #[cfg(not(windows))]
-fn enable_row_mode() -> Result<()> {
+fn enable_raw_mode() -> Result<()> {
     use rustix::termios::{self, LocalModes, OptionalActions};
 
     let stdin = std::io::stdin();
@@ -275,7 +275,7 @@ fn enable_row_mode() -> Result<()> {
 }
 
 #[cfg(not(windows))]
-fn disable_row_mode() -> Result<()> {
+fn disable_raw_mode() -> Result<()> {
     use rustix::termios::{self, OptionalActions};
 
     if let Some(termios) = TERMINAL_MODE_PRIOR_RAW_MODE.lock().unwrap().as_ref() {
@@ -303,8 +303,80 @@ fn font_size_fallback() -> Option<FontSize> {
     Some((x / cols, y / rows))
 }
 
+#[cfg(windows)]
+static ORIGINAL_IN_MODE: std::sync::Mutex<Option<windows::Win32::System::Console::CONSOLE_MODE>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(windows)]
+use windows::Win32::Foundation::HANDLE;
+
+#[cfg(windows)]
+fn current_in_handle() -> Result<HANDLE> {
+    use windows::{
+        core::PCWSTR,
+        Win32::{
+            Foundation::{GENERIC_READ, GENERIC_WRITE, HANDLE},
+            Storage::FileSystem::{
+                self, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+            },
+        },
+    };
+
+    let utf16: Vec<u16> = "CONIN$\0".encode_utf16().collect();
+    let utf16_ptr: *const u16 = utf16.as_ptr();
+
+    Ok(unsafe {
+        FileSystem::CreateFileW(
+            PCWSTR(utf16_ptr),
+            (GENERIC_READ | GENERIC_WRITE).0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAGS_AND_ATTRIBUTES(0),
+            HANDLE::default(),
+        )
+    }?)
+}
+
+#[cfg(windows)]
+fn enable_raw_mode() -> Result<()> {
+    use windows::Win32::System::Console::{
+        self, CONSOLE_MODE, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT,
+    };
+
+    let in_handle = current_in_handle()?;
+
+    let mut original_in_mode = CONSOLE_MODE::default();
+    unsafe { Console::GetConsoleMode(in_handle, &mut original_in_mode) }?;
+    *ORIGINAL_IN_MODE.lock().unwrap() = Some(original_in_mode);
+
+    let requested_in_modes = !ENABLE_ECHO_INPUT & !ENABLE_LINE_INPUT & !ENABLE_PROCESSED_INPUT;
+    let in_mode = original_in_mode & requested_in_modes;
+    unsafe { Console::SetConsoleMode(in_handle, in_mode) }?;
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn disable_raw_mode() -> Result<()> {
+    use windows::Win32::System::Console;
+
+    let in_handle = current_in_handle()?;
+
+    if let Some(in_mode) = ORIGINAL_IN_MODE.lock().unwrap().as_ref() {
+        unsafe { Console::SetConsoleMode(in_handle, *in_mode) }?;
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn font_size_fallback() -> Option<FontSize> {
+    Some((10, 20))
+}
+
 fn query_stdio_capabilities(is_tmux: bool) -> Result<(Option<ProtocolType>, Option<FontSize>)> {
-    enable_row_mode()?;
+    enable_raw_mode()?;
 
     let (start, escape, end) = if is_tmux {
         ("\x1bPtmux;", "\x1b\x1b", "\x1b\\")
@@ -351,7 +423,7 @@ fn query_stdio_capabilities(is_tmux: bool) -> Result<(Option<ProtocolType>, Opti
     }
 
     // Reset to previous termios attributes.
-    disable_row_mode()?;
+    disable_raw_mode()?;
 
     let mut proto = None;
     let mut font_size = None;

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -494,8 +494,8 @@ impl Parser {
                     // This is just easier than actually parsing the string.
                     let is_sixel = self.data.contains(";4;")
                         || self.data.contains("?4;")
-                        || self.data.contains(";4")
-                        || self.data.contains("?4");
+                        || self.data.contains(";4c")
+                        || self.data.contains("?4c");
                     self.data = String::new();
                     self.sequence = ParsedResponse::Unknown;
                     return Some(ParsedResponse::Sixel(is_sixel));

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -63,7 +63,7 @@ impl Picker {
     /// entering alternate screen but before reading terminal events.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// use ratatui_image::picker::Picker;
     /// let mut picker = Picker::from_query_stdio();
     /// ```

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -501,11 +501,13 @@ impl Parser {
             }
             ParsedResponse::Sixel(_) => match next {
                 'c' => {
+                    self.data.push(next);
+
                     // This is just easier than actually parsing the string.
                     let is_sixel = self.data.contains(";4;")
                         || self.data.contains("?4;")
-                        || self.data.contains(";4")
-                        || self.data.contains("?4");
+                        || self.data.contains(";4c")
+                        || self.data.contains("?4c");
                     self.data = String::new();
                     self.sequence = ParsedResponse::Unknown;
                     return Some(ParsedResponse::Sixel(is_sixel));

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -494,8 +494,8 @@ impl Parser {
                     // This is just easier than actually parsing the string.
                     let is_sixel = self.data.contains(";4;")
                         || self.data.contains("?4;")
-                        || self.data.contains(";4c")
-                        || self.data.contains("?4c");
+                        || self.data.contains(";4")
+                        || self.data.contains("?4");
                     self.data = String::new();
                     self.sequence = ParsedResponse::Unknown;
                     return Some(ParsedResponse::Sixel(is_sixel));


### PR DESCRIPTION
- Since rustix is already an integral part of running on non-Windows, remove it from features and make it a non-Windows dependency.
- Extracted several platform-dependent functions to reuse most of the query_stdio_capabilities code.
- Fixed a bug in Parser that incorrectly recognized older versions of Windows Terminal as supporting sixel.
- Temporarily skipped one of the doc tests due to it not working correctly when running the test on Windows (it works fine when running the test on its own)