### PR TITLE
Explain minimum supported kitty in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Terminal  | Protocol | OK | Notes
 ----------|----------|----|-------
 Xterm     | `Sixel`  | ✔️  | Run with `-ti 340` to make sure sixel support is enabled.
 Foot      | `Sixel`  | ✔️  | Wayland.
-Kitty     | `Kitty`  | ✔️  | Reference for the `Kitty` protocol.
+Kitty     | `Kitty`  | ✔️  | Reference for the `Kitty` protocol (requires Kitty 0.28.0 or later).
 Wezterm   | `iTerm2` | ✔️  | Also would support `Sixel` and `Kitty`, but only `iTerm2` actually works bug-free.
 Ghostty   | `Kitty`  | ✔️  | Implements `Kitty` with unicode placeholders.
 Rio       | `iTerm2` | ✔️  | Also supports `Sixel` but has glitches.


### PR DESCRIPTION
Per #29, ratatui-image only supports the kitty protocol on versions of `kitty` 0.28.0 or newer. As of this second, Debian Stable (bookworm) apt is serving a kitty version 0.26.5 (and in my testing, ratatui-image kitty support does not work on it). Because people may encounter this in the wild (I did), it should be documented.