### PR TITLE
Make `Image::new` use a non-mutable borrow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,11 +146,11 @@ pub type FontSize = (u16, u16);
 /// }
 /// ```
 pub struct Image<'a> {
-    image: &'a mut Protocol,
+    image: &'a Protocol,
 }
 
 impl<'a> Image<'a> {
-    pub fn new(image: &'a mut Protocol) -> Self {
+    pub fn new(image: &'a Protocol) -> Self {
         Self { image }
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -25,7 +25,7 @@ pub mod sixel;
 
 trait ProtocolTrait: Send + Sync {
     /// Render the currently resized and encoded data to the buffer.
-    fn render(&mut self, area: Rect, buf: &mut Buffer);
+    fn render(&self, area: Rect, buf: &mut Buffer);
 
     // Get the area of the image.
     #[allow(dead_code)]
@@ -50,8 +50,8 @@ pub enum Protocol {
 }
 
 impl Protocol {
-    pub(crate) fn render(&mut self, area: Rect, buf: &mut Buffer) {
-        let inner: &mut dyn ProtocolTrait = match self {
+    pub(crate) fn render(&self, area: Rect, buf: &mut Buffer) {
+        let inner: &dyn ProtocolTrait = match self {
             Self::Halfblocks(halfblocks) => halfblocks,
             Self::Sixel(sixel) => sixel,
             Self::Kitty(kitty) => kitty,

--- a/src/protocol/halfblocks.rs
+++ b/src/protocol/halfblocks.rs
@@ -63,7 +63,7 @@ fn encode(img: &DynamicImage, rect: Rect) -> Vec<HalfBlock> {
 }
 
 impl ProtocolTrait for Halfblocks {
-    fn render(&mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         for (i, hb) in self.data.iter().enumerate() {
             let x = i as u16 % self.area.width;
             let y = i as u16 / self.area.width;

--- a/src/protocol/iterm2.rs
+++ b/src/protocol/iterm2.rs
@@ -59,7 +59,7 @@ fn encode(img: &DynamicImage, render_area: Rect, is_tmux: bool) -> Result<String
 }
 
 impl ProtocolTrait for Iterm2 {
-    fn render(&mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         render(self.area, &self.data, area, buf, false)
     }
 

--- a/src/protocol/sixel.rs
+++ b/src/protocol/sixel.rs
@@ -66,7 +66,7 @@ fn encode(img: &DynamicImage, is_tmux: bool) -> Result<String> {
 }
 
 impl ProtocolTrait for Sixel {
-    fn render(&mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         render(self.area, &self.data, area, buf, false)
     }
 


### PR DESCRIPTION
While trying to update to a more recent `ratatui-image`, I noticed that `Image::new` now takes `&mut Protocol`. I initially tried to switch to using `&mut` instead, but found that difficult to do since it would mean taking multiple `&mut` references. It looks like the `mut` is only needed for `Protocol::Kitty` so that it can track whether or not the transmit string has been sent already, so I've adapted the logic to use an `AtomicBool` to track when it's sent instead so that `Image::new` can go back to taking `&Protocol` again.