### PR TITLE
Resize using area returned by `needs_resize`

### DIFF
--- a/src/picker.rs
+++ b/src/picker.rs
@@ -212,15 +212,7 @@ impl Picker {
         let (image, area) =
             match resize.needs_resize(&source, self.font_size, source.desired, size, false) {
                 Some(area) => {
-                    // Not exactly sure why this is necessary only for Protocol and not
-                    // StatefulProtocol, but the image proportion comes out wrong if we don't
-                    // divide height by half here.
-                    let font_size = if self.protocol_type == ProtocolType::Halfblocks {
-                        (self.font_size.0, self.font_size.1 / 2)
-                    } else {
-                        self.font_size
-                    };
-                    let image = resize.resize(&source, font_size, size, self.background_color);
+                    let image = resize.resize(&source, self.font_size, area, self.background_color);
                     (image, area)
                 }
                 None => (source.image, source.desired),


### PR DESCRIPTION
After updating to `1.0.5` to `6.0.0`, an iamb user noticed that the halfblocks output was resized in a way that stretched the image. After some digging, I found that the issue was due to the `resize.resize()` call using the original `size: Rect`, instead of the `Rect` returned by `needs_resize`. Removing the special case logic for `font_size` and using the returned `Rect` seems to work correctly for what I've tried so far.

I'll try verifying that things look right with Kitty and iTerm2 later.

## `sixel` in foot

![image](https://github.com/user-attachments/assets/5c1501a8-105c-467c-bfe8-549df3036f71)


## `halfblocks` in foot

![image](https://github.com/user-attachments/assets/f7d8f49f-e21a-49ea-a569-66ef359b65ec)

## `halfblocks` in GNOME Terminal

![image](https://github.com/user-attachments/assets/adb60911-6295-4e9b-b630-61e0ff6c43e0)

## Original `iamb` example

![image](https://github.com/user-attachments/assets/60a294d1-94ff-4d60-8302-af9530150f0a)

