### PR TITLE
Add support for Bobcat terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ iTerm2    | `iTerm2` | ✔️ | Reference for the `iTerm2` protocol. Mac only.
 Rio       | `iTerm2` | ✔️ | Also supports `Sixel` but has glitches.
 mlterm    | `Sixel`  | ✔️ | Quite slow but no glitches.
 Black Box | `Sixel`  | ✔️ | Confirmed only with the flatpak version, most distro packages don't enable Sixel support.
+Bobcat    | `iTerm2` | ✔️ | Works on all versions and builds. Falls back to `Sixel` if `TERM_PROGRAM` variable is not set.
 Alacritty | `Sixel`  | ❌ | [There is a sixel fork](https://github.com/microo8/alacritty-sixel), but it's probably never getting merged, and does not clear graphics.
 Konsole   | `Sixel`  | ❌ | [Not really fixed in 24.12](https://bugs.kde.org/show_bug.cgi?id=456354)
 Contour   | `Sixel`  | ❌ | Does not clear graphics.

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -294,6 +294,7 @@ fn iterm2_from_env() -> Option<ProtocolType> {
             || term_program.contains("Tabby")
             || term_program.contains("Hyper")
             || term_program.contains("rio")
+            || term_program.contains("Bobcat")
     }) {
         return Some(ProtocolType::Iterm2);
     }


### PR DESCRIPTION
This PR adds support for the [Bobcat](https://github.com/ismail-yilmaz/Bobcat) terminal emulator to the `ratatui-image` crate. Bobcat is a cross-platform terminal emulator that supports a wide range of ANSI and SGR sequences required by the library, including inline image rendering capabilities (via iTerm2, Sixel).

## Changes

- Added `"Bobcat"` as a recognized terminal in the detection logic.
- Updated documentation and comments to reflect this addition (if applicable).


[Ekran Kaydı 2025-06-01 17-53-06.webm](https://github.com/user-attachments/assets/5ebc845c-3e08-476a-930e-c832ec8286be)
