### PR TITLE
Add support for warp terminal

### DIFF
--- a/src/picker.rs
+++ b/src/picker.rs
@@ -295,6 +295,7 @@ fn iterm2_from_env() -> Option<ProtocolType> {
             || term_program.contains("Hyper")
             || term_program.contains("rio")
             || term_program.contains("Bobcat")
+            || term_program.contains("WarpTerminal")
     }) {
         return Some(ProtocolType::Iterm2);
     }


### PR DESCRIPTION
According to [their changelog](https://docs.warp.dev/getting-started/changelog#id-2025.03.05-v0.2025.03.05.08.02), warp has support for iterm2 images. Since it doesn't support the necessary parts of kitty's protocol yet, I think it would just be best to add support for what it does work with for now.