### PR TITLE
Switch to base64-simd for faster base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "owo-colors"
 version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,7 +1550,7 @@ dependencies = [
 name = "ratatui-image"
 version = "8.0.1"
 dependencies = [
- "base64",
+ "base64-simd",
  "color-eyre",
  "crossterm 0.29.0",
  "futures",
@@ -2281,6 +2297,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio = ["dep:tokio"]
 image = { version = "^0.25.6", default-features = false, features = ["jpeg"] }
 icy_sixel = { version = "^0.1.1" }
 serde = { version = "^1.0", optional = true, features = ["derive"] }
-base64 = { version = "^0.21.2" }
+base64-simd = { version = "0.8" }
 rand = { version = "^0.8.5" }
 ratatui = { version = "^0.29.0", default-features = false, features = [] }
 thiserror = { version = "1.0.59" }

--- a/src/protocol/iterm2.rs
+++ b/src/protocol/iterm2.rs
@@ -1,5 +1,4 @@
 //! ITerm2 protocol implementation.
-use base64::{Engine, engine::general_purpose};
 use image::DynamicImage;
 use ratatui::{buffer::Buffer, layout::Rect};
 use std::{cmp::min, format, io::Cursor};
@@ -30,7 +29,7 @@ fn encode(img: &DynamicImage, render_area: Rect, is_tmux: bool) -> Result<String
     let mut png: Vec<u8> = vec![];
     img.write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)?;
 
-    let data = general_purpose::STANDARD.encode(&png);
+    let data = base64_simd::STANDARD.encode_to_string(&png);
 
     let (start, escape, end) = Parser::escape_tmux(is_tmux);
 

--- a/src/protocol/kitty.rs
+++ b/src/protocol/kitty.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::{Result, picker::cap_parser::Parser};
-use base64::{Engine, engine::general_purpose};
 use image::DynamicImage;
 use ratatui::{buffer::Buffer, layout::Rect};
 
@@ -172,7 +171,7 @@ fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool) -> String {
     let chunks = bytes.chunks(4096 / 4 * 3);
     let chunk_count = chunks.len();
     for (i, chunk) in chunks.enumerate() {
-        let payload = general_purpose::STANDARD.encode(chunk);
+        let payload = base64_simd::STANDARD.encode_to_string(chunk);
         // tmux seems to only allow a limited amount of data in each passthrough sequence, since
         // we're already chunking the data for the kitty protocol that's a good enough chunk size to
         // use for the passthrough chunks too.


### PR DESCRIPTION
the `base64-simd` crate provides base64 algorithms implemented with simd intrinsics instead of plain rust, with an API basically identical to the `base64` crate. I see no reason to stay with the normal `base64` crate when such an alternative exists.