### PR TITLE
unify clear_area() for sixel and iterm2, simplify single row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Other
+- Unify the "clear_area" function across sixel and iterm2
+- Skip cursor movements in "clear_area" if only one row.
+- Add a criterion benchmark
+
 ## [10.0.6](https://github.com/benjajaja/ratatui-image/compare/v10.0.5...v10.0.6) - 2026-02-19
 
 ### Other

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::hash_map::DefaultHasher,
+    fmt::Write,
     hash::{Hash, Hasher},
 };
 
@@ -252,5 +253,21 @@ impl ImageSource {
         let width = (img_width as f32 / char_width as f32).ceil() as u16;
         let height = (img_height as f32 / char_height as f32).ceil() as u16;
         Rect::new(0, 0, width, height)
+    }
+}
+
+// Transparency needs explicit erasing of stale characters, or they stay behind the rendered
+// image due to skipping of the following characters _in the terminal buffer_.
+// DECERA does not work in WezTerm, however ECH and and cursor CUD and CUU do.
+// For each line, erase `width` characters, then move back and place image.
+fn clear_area(data: &mut String, escape: &str, width: u16, height: u16) {
+    if height == 1 {
+        // If the image is a single row then we don't need to move the cursor around at all.
+        write!(data, "{escape}[{width}X").unwrap();
+    } else {
+        for _ in 0..height {
+            write!(data, "{escape}[{width}X{escape}[1B").unwrap();
+        }
+        write!(data, "{escape}[{height}A").unwrap();
     }
 }

--- a/src/protocol/iterm2.rs
+++ b/src/protocol/iterm2.rs
@@ -5,7 +5,7 @@ use std::{cmp::min, fmt::Write, io::Cursor};
 
 use crate::{Result, picker::cap_parser::Parser};
 
-use super::{ProtocolTrait, StatefulProtocolTrait};
+use super::{ProtocolTrait, StatefulProtocolTrait, clear_area};
 
 #[derive(Clone, Default)]
 pub struct Iterm2 {
@@ -31,18 +31,10 @@ fn encode(img: &DynamicImage, render_area: Rect, is_tmux: bool) -> Result<String
 
     let (start, escape, end) = Parser::escape_tmux(is_tmux);
 
-    // Transparency needs explicit erasing of stale characters, or they stay behind the rendered
-    // image due to skipping of the following characters _in the buffer_.
-    // DECERA does not work in WezTerm, however ECH and and cursor CUD and CUU do.
-    // For each line, erase `width` characters, then move back and place image.
-    // TODO: unify this with sixel
     let width = render_area.width;
     let height = render_area.height;
     let mut seq = String::from(start);
-    for _ in 0..height {
-        write!(seq, "{escape}[{width}X{escape}[1B").unwrap();
-    }
-    write!(seq, "{escape}[{height}A").unwrap();
+    clear_area(&mut seq, escape, width, height);
 
     write!(
         seq,

--- a/src/protocol/sixel.rs
+++ b/src/protocol/sixel.rs
@@ -8,9 +8,9 @@
 use icy_sixel::{EncodeOptions, sixel_encode};
 use image::DynamicImage;
 use ratatui::{buffer::Buffer, layout::Rect};
-use std::{cmp::min, fmt::Write};
+use std::cmp::min;
 
-use super::{ProtocolTrait, StatefulProtocolTrait};
+use super::{ProtocolTrait, StatefulProtocolTrait, clear_area};
 use crate::{Result, errors::Errors, picker::cap_parser::Parser};
 
 // Fixed sixel protocol
@@ -39,10 +39,6 @@ fn encode(img: &DynamicImage, area: Rect, is_tmux: bool) -> Result<String> {
     let bytes = img_rgba8.as_raw();
     let (start, escape, end) = Parser::escape_tmux(is_tmux);
 
-    // Transparency needs explicit erasing of stale characters, or they stay behind the rendered
-    // image due to skipping of the following characters _in the buffer_.
-    // See comment in iterm2::encode about why we use ECH and movements instead of DECERA.
-    // TODO: unify this with iterm2
     let width = area.width;
     let height = area.height;
 
@@ -57,18 +53,12 @@ fn encode(img: &DynamicImage, area: Rect, is_tmux: bool) -> Result<String> {
         // The clear sequence must be inside the tmux passthrough since it uses
         // doubled escapes.
         data.push_str(start);
-        for _ in 0..height {
-            write!(data, "{escape}[{width}X{escape}[1B").unwrap();
-        }
-        write!(data, "{escape}[{height}A").unwrap();
+        clear_area(&mut data, escape, width, height);
         data.push_str(escape);
         data.push_str(&sixel_data[1..]);
         data.push_str(end);
     } else {
-        for _ in 0..height {
-            write!(data, "{escape}[{width}X{escape}[1B").unwrap();
-        }
-        write!(data, "{escape}[{height}A").unwrap();
+        clear_area(&mut data, escape, width, height);
         data.push_str(&sixel_data);
     }
     Ok(data)


### PR DESCRIPTION
1. Unify clear_area() fn for sixel and iterm2.
2. If `height == 1`, no need for cursor movement at all.

There is a use case for slicing up images so that only some rows can be rendered. In that case it is beneficial to skip the useless cursor movements.