### PR TITLE
add Protocol::needs_placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - SlicedImage and SlicedProtocol for partially rendering images (horizontal slices)
+- `Protocol::needs_placeholder` that returns a `Rect` for a placeholder if the image would not
+  render.
 
 ### Removed
 - feature kitty-offset in favor of SlicedImage and SlicedProtocol

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -21,7 +21,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect, Size},
     style::{Color, Stylize},
     text::{Line, Span, Text},
-    widgets::{Block, Borders, Paragraph, Wrap},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap},
 };
 use ratatui_image::{
     Image, Resize, StatefulImage,
@@ -259,15 +259,24 @@ fn ui(f: &mut Frame<'_>, app: &mut App) {
     match app.show_images {
         ShowImages::Resized => {}
         _ => {
-            let image = Image::new(&app.image_static);
             // Let it be surrounded by styled text.
-            let offset_area = Rect {
+            let area = Rect {
                 x: area.x + 1,
                 y: area.y + 1,
                 width: area.width.saturating_sub(2),
                 height: area.height.saturating_sub(2),
             };
-            f.render_widget(image, offset_area);
+
+            if let Some(placeholder_area) = app.image_static.needs_placeholder(area) {
+                let placeholder = Block::bordered()
+                    .border_type(BorderType::QuadrantOutside)
+                    .bg(Color::DarkGray);
+                f.render_widget(Clear {}, placeholder.inner(placeholder_area));
+                f.render_widget(placeholder, placeholder_area);
+            } else {
+                let image = Image::new(&app.image_static);
+                f.render_widget(image, area);
+            }
         }
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -72,6 +72,27 @@ impl Protocol {
         };
         inner.size()
     }
+
+    /// Returns a placeholder area, if the image will not render into the given area, or `None`.
+    ///
+    /// The returned [`ratatui::layout::Rect`] is the area the image would cover, constrained by
+    /// the size of `area` argument, if the image does not fit.
+    ///
+    /// Kitty and Halfblocks can always render partially, so they always return `None`.
+    pub fn needs_placeholder(&self, area: Rect) -> Option<Rect> {
+        let image_size = self.size();
+        if area.width < image_size.width
+            || area.height < image_size.height
+                && (matches!(self, Self::Sixel(_)) || matches!(self, Self::Halfblocks(_)))
+        {
+            let mut placeholder_area = area;
+            placeholder_area.width = placeholder_area.width.min(image_size.width);
+            placeholder_area.height = placeholder_area.height.min(image_size.height);
+            return Some(placeholder_area);
+        }
+        // Kitty and Halfblocks can render into a smaller area.
+        None
+    }
 }
 
 /// A stateful resizing image protocol for the [crate::StatefulImage] widget.


### PR DESCRIPTION
Returns a placeholder `Rect` if the image would not render in the given `area`.

Kitty and Halfblocks always render into smaller areas and return `None`.

Make use of `needs_placeholder` in the demo.