### PR TITLE
use ratatui::layout::Size instead of Rect where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - feature kitty-offset in favor of SlicedImage and SlicedProtocol
 
+### Changed
+- `FontSize = (u16, u16)` alias became `struct FontSize { width: u16, height: u16 }`
+- Replaced `Rect` with `Size` everywhere it was used for size, or without positioning
+  - `Picker::new_protocol()`
+  - `Resize::render_area()`
+  - `ProtocolTrait::area() -> Rect` became `ProtocolTrait::size() -> Size`
+  - `StatefulProtocol::size_for()`
+  - `ResizeEncodeRender::resize_encode()`
+  - `ResizeEncodeRender::needs_resize()`
+  - `Halfblocks::new()`
+  - `Kitty::new()`
+  - `Sixel::new()`
+  - `ITerm2::new()`
+  - `ImageSource::round_pixel_size_to_cells()`
+  - `chafa::encode()`
+  - `primitive::encode()`
+  - Any places missed here should be trivial to fix
+
 ## [10.0.8](https://github.com/ratatui/ratatui-image/compare/v10.0.7...v10.0.8) - 2026-04-30
 
 ### Added

--- a/benches/protocols.rs
+++ b/benches/protocols.rs
@@ -1,6 +1,10 @@
 #![expect(clippy::unwrap_used)]
 use criterion::{Criterion, criterion_group, criterion_main};
-use ratatui::{buffer::Buffer, layout::Rect, widgets::StatefulWidget as _};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Rect, Size},
+    widgets::StatefulWidget as _,
+};
 use ratatui_image::{
     Resize, ResizeEncodeRender, StatefulImage,
     picker::{Picker, ProtocolType},
@@ -47,7 +51,7 @@ fn bench_resize_encode_render(c: &mut Criterion) {
                 picker.set_protocol_type(protocol);
                 let mut proto = picker.new_resize_protocol(black_box(image.clone()));
 
-                let area = Rect::new(0, 0, 10, 10);
+                let area = Size::new(10, 10);
                 proto.resize_encode(&Resize::Fit(None), black_box(area));
             })
         });

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -18,7 +18,7 @@ use image::DynamicImage;
 use ratatui::{
     Frame, Terminal,
     backend::Backend,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Rect, Size},
     style::{Color, Stylize},
     text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph, Wrap},
@@ -67,8 +67,8 @@ struct App {
     image_scale_state: StatefulProtocol,
 }
 
-fn size() -> Rect {
-    Rect::new(0, 0, 30, 16)
+fn size() -> Size {
+    Size::new(30, 16)
 }
 
 impl App {
@@ -296,7 +296,11 @@ fn ui(f: &mut Frame<'_>, app: &mut App) {
                 Span::from("t").green(),
                 Span::from(format!(": toggle ({:?})", app.show_images)),
             ]),
-            Line::from(format!("Font size: {:?}", app.picker.font_size())),
+            Line::from(format!(
+                "Font size: {}×{}",
+                app.picker.font_size().width,
+                app.picker.font_size().height
+            )),
             Line::from(format!("Protocol: {:?}", app.picker.protocol_type())),
         ]),
         area,

--- a/examples/sliced.rs
+++ b/examples/sliced.rs
@@ -28,8 +28,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let dyn_img = image::ImageReader::open("./assets/Ada.png")?.decode()?;
     let font_size = picker.font_size();
     let size = Size::new(
-        dyn_img.width().div_ceil(font_size.0 as u32) as u16,
-        dyn_img.height().div_ceil(font_size.1 as u32) as u16,
+        dyn_img.width().div_ceil(font_size.width as u32) as u16,
+        dyn_img.height().div_ceil(font_size.height as u32) as u16,
     );
 
     let mut terminal_size = Size::default();
@@ -135,9 +135,6 @@ fn ui(f: &mut Frame<'_>, app: &App) {
             Rect::new(inner_area.x, inner_area.y + i, inner_area.width, 1),
         );
     }
-
-    let mut area: Rect = app.size.into();
-    area.x = 1;
 
     f.render_widget(
         SlicedImage::new(&app.sliced, app.size, app.position),

--- a/examples/thread.rs
+++ b/examples/thread.rs
@@ -8,7 +8,7 @@ use std::{
 use ratatui::{
     Frame,
     crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
-    layout::{Position, Rect},
+    layout::{Position, Rect, Size},
     style::{Color, Stylize},
     widgets::{Block, Borders, Clear, Paragraph},
 };
@@ -21,7 +21,7 @@ use ratatui_image::{
 
 struct App {
     async_state: ThreadProtocol,
-    last_known_size: Rect,
+    last_known_size: Size,
     logo_pos: Position,
     logo_size: f64,
     source_code_lines: Vec<String>,
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut app = App {
         async_state: ThreadProtocol::new(tx_worker, Some(picker.new_resize_protocol(dyn_img))),
-        last_known_size: Rect::default(),
+        last_known_size: Size::default(),
         logo_pos: Position { x: 1, y: 1 },
         logo_size: 0.1,
         source_code_lines: Vec::new(),
@@ -140,7 +140,9 @@ fn ui(f: &mut Frame<'_>, app: &mut App) {
         f.render_widget(p, Rect::new(inner_area.x, y, inner_area.width, 1));
     }
 
-    let size_for = app.async_state.size_for(Resize::Fit(None), inner_area);
+    let size_for = app
+        .async_state
+        .size_for(Resize::Fit(None), inner_area.into());
 
     let mut size = size_for.unwrap_or(app.last_known_size);
     app.last_known_size = size;
@@ -148,7 +150,7 @@ fn ui(f: &mut Frame<'_>, app: &mut App) {
     size.width = (f64::from(size.width) * app.logo_size).ceil() as u16;
     size.height = (f64::from(size.height) * app.logo_size).ceil() as u16;
 
-    let mut image_block_area = size;
+    let mut image_block_area: Rect = size.into();
     image_block_area.width += 2;
     image_block_area.height += 2;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ use image::{DynamicImage, ImageBuffer, Rgba, imageops};
 use protocol::{ImageSource, Protocol};
 use ratatui::{
     buffer::Buffer,
-    layout::Rect,
+    layout::{Rect, Size},
     widgets::{StatefulWidget, Widget},
 };
 
@@ -156,7 +156,23 @@ pub use image::imageops::FilterType;
 type Result<T> = std::result::Result<T, errors::Errors>;
 
 /// The terminal's font size in `(width, height)`
-pub type FontSize = (u16, u16);
+#[derive(Copy, Clone, Debug)]
+pub struct FontSize {
+    pub width: u16,
+    pub height: u16,
+}
+
+impl FontSize {
+    pub const fn new(width: u16, height: u16) -> Self {
+        Self { width, height }
+    }
+}
+
+impl From<(u16, u16)> for FontSize {
+    fn from((width, height): (u16, u16)) -> Self {
+        Self::new(width, height)
+    }
+}
 
 /// Fixed size image widget that uses [Protocol].
 ///
@@ -197,7 +213,7 @@ impl Widget for Image<'_> {
 pub trait ResizeEncodeRender {
     /// Resize and encode if necessary, and render immediately.
     fn resize_encode_render(&mut self, resize: &Resize, area: Rect, buf: &mut Buffer) {
-        if let Some(rect) = self.needs_resize(resize, area) {
+        if let Some(rect) = self.needs_resize(resize, area.into()) {
             self.resize_encode(resize, rect);
         }
         self.render(area, buf);
@@ -207,7 +223,7 @@ pub trait ResizeEncodeRender {
     /// that next call for the given area does not need to redo the work.
     ///
     /// This can be done in a background thread, and the result is stored in this [protocol::StatefulProtocol].
-    fn resize_encode(&mut self, resize: &Resize, area: Rect);
+    fn resize_encode(&mut self, resize: &Resize, size: Size);
 
     /// Render the currently resized and encoded data to the buffer.
     fn render(&mut self, area: Rect, buf: &mut Buffer);
@@ -216,7 +232,7 @@ pub trait ResizeEncodeRender {
     /// This can be called by the UI thread to check if this [protocol::StatefulProtocol] should be sent off
     /// to some background thread/task to do the resizing and encoding, instead of rendering. The
     /// thread should then return the [protocol::StatefulProtocol] so that it can be rendered.
-    fn needs_resize(&self, resize: &Resize, area: Rect) -> Option<Rect>;
+    fn needs_resize(&self, resize: &Resize, size: Size) -> Option<Size>;
 }
 
 /// Resizeable image widget that uses a [protocol::StatefulProtocol] state.
@@ -331,11 +347,11 @@ impl Resize {
         &self,
         source: &ImageSource,
         font_size: FontSize,
-        area: Rect,
+        size: Size,
         background_color: Rgba<u8>,
     ) -> DynamicImage {
-        let width = (area.width * font_size.0) as u32;
-        let height = (area.height * font_size.1) as u32;
+        let width = (size.width * font_size.width) as u32;
+        let height = (size.height * font_size.height) as u32;
 
         // Resize/Crop/etc., fitting a multiple of font-size, but not necessarily the area.
         let mut image = self.resize_image(source, width, height);
@@ -351,35 +367,35 @@ impl Resize {
 
     /// Check if [`ImageSource`]'s "desired" fits into `area` and is different than `current`.
     ///
-    /// The returned `Rect` is the area the image needs to be resized to, depending on the resize
+    /// The returned `Size` is the area the image needs to be resized to, depending on the resize
     /// type.
     pub fn needs_resize(
         &self,
         image: &ImageSource,
         font_size: FontSize,
-        current: Rect,
-        area: Rect,
+        current: Size,
+        size: Size,
         force: bool,
-    ) -> Option<Rect> {
+    ) -> Option<Size> {
         let desired = image.desired;
         // Check if resize is needed at all.
         if !force
             && !matches!(self, &Resize::Scale(_))
-            && desired.width <= area.width
-            && desired.height <= area.height
+            && desired.width <= size.width
+            && desired.height <= size.height
             && desired == current
         {
-            let width = (desired.width * font_size.0) as u32;
-            let height = (desired.height * font_size.1) as u32;
+            let width = (desired.width * font_size.width) as u32;
+            let height = (desired.height * font_size.height) as u32;
             if image.image.width() == width || image.image.height() == height {
                 return None;
             }
         }
 
-        let rect = self.render_area(image, font_size, area);
-        debug_assert!(rect.width <= area.width, "needs_resize exceeds area width");
+        let rect = self.render_area(image, font_size, size);
+        debug_assert!(rect.width <= size.width, "needs_resize exceeds area width");
         debug_assert!(
-            rect.height <= area.height,
+            rect.height <= size.height,
             "needs_resize exceeds area height"
         );
         if force || rect != current {
@@ -388,11 +404,11 @@ impl Resize {
         None
     }
 
-    pub fn render_area(&self, image: &ImageSource, font_size: FontSize, available: Rect) -> Rect {
+    pub fn render_area(&self, image: &ImageSource, font_size: FontSize, available: Size) -> Size {
         let (width, height) = self.needs_resize_pixels(
             &image.image,
-            (available.width as u32) * (font_size.0 as u32),
-            (available.height as u32) * (font_size.1 as u32),
+            (available.width as u32) * (font_size.width as u32),
+            (available.height as u32) * (font_size.height as u32),
         );
         ImageSource::round_pixel_size_to_cells(width, height, font_size)
     }
@@ -474,7 +490,7 @@ mod tests {
 
     use super::*;
 
-    const FONT_SIZE: FontSize = (10, 10);
+    const FONT_SIZE: FontSize = FontSize::new(10, 10);
 
     fn s(w: u16, h: u16) -> ImageSource {
         let image: DynamicImage =
@@ -482,8 +498,8 @@ mod tests {
         ImageSource::new(image, FONT_SIZE, [0, 0, 0, 0].into())
     }
 
-    fn r(w: u16, h: u16) -> Rect {
-        Rect::new(0, 0, w, h)
+    fn r(w: u16, h: u16) -> Size {
+        Size::new(w, h)
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -20,7 +20,7 @@ use crate::{
 use cap_parser::{Parser, QueryStdioOptions, Response};
 use image::{DynamicImage, Rgba};
 use rand::random;
-use ratatui::layout::Rect;
+use ratatui::layout::Size;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -110,7 +110,7 @@ impl Picker {
             // This is completely arbitrary. For halfblocks, it doesn't have to be precise
             // since we're not rendering pixels. It should be roughly 1:2 ratio, and some
             // reasonable size.
-            font_size: (10, 20),
+            font_size: FontSize::new(10, 20),
             background_color: DEFAULT_BACKGROUND,
             protocol_type: ProtocolType::Halfblocks,
             is_tmux: false,
@@ -176,7 +176,7 @@ impl Picker {
         let (is_tmux, _tmux_proto) = detect_tmux_and_outer_protocol_from_env();
 
         Self {
-            font_size: (10, 20),
+            font_size: FontSize::new(10, 20),
             background_color: DEFAULT_BACKGROUND,
             protocol_type: ProtocolType::Halfblocks,
             is_tmux,
@@ -237,17 +237,17 @@ impl Picker {
     /// Returns a new protocol.
     ///
     /// The image must match the given area at the terminal's current font size.
-    pub(crate) fn new_protocol_raw(&self, image: DynamicImage, area: Rect) -> Result<Protocol> {
+    pub(crate) fn new_protocol_raw(&self, image: DynamicImage, size: Size) -> Result<Protocol> {
         match self.protocol_type {
-            ProtocolType::Halfblocks => Ok(Protocol::Halfblocks(Halfblocks::new(image, area)?)),
-            ProtocolType::Sixel => Ok(Protocol::Sixel(Sixel::new(image, area, self.is_tmux)?)),
+            ProtocolType::Halfblocks => Ok(Protocol::Halfblocks(Halfblocks::new(image, size)?)),
+            ProtocolType::Sixel => Ok(Protocol::Sixel(Sixel::new(image, size, self.is_tmux)?)),
             ProtocolType::Kitty => Ok(Protocol::Kitty(Kitty::new(
                 image,
-                area,
+                size,
                 rand::random(),
                 self.is_tmux,
             )?)),
-            ProtocolType::Iterm2 => Ok(Protocol::ITerm2(Iterm2::new(image, area, self.is_tmux)?)),
+            ProtocolType::Iterm2 => Ok(Protocol::ITerm2(Iterm2::new(image, size, self.is_tmux)?)),
         }
     }
 
@@ -255,7 +255,7 @@ impl Picker {
     pub fn new_protocol(
         &self,
         image: DynamicImage,
-        size: Rect,
+        size: Size,
         resize: Resize,
     ) -> Result<Protocol> {
         let source = ImageSource::new(image, self.font_size, self.background_color);
@@ -424,7 +424,7 @@ fn font_size_fallback() -> Option<FontSize> {
         return None;
     }
 
-    Some((x / cols, y / rows))
+    Some(FontSize::new(x / cols, y / rows))
 }
 
 #[cfg(windows)]
@@ -510,7 +510,7 @@ fn interpret_parser_responses(
             Response::RectangularOps => Some(Capability::RectangularOps),
             Response::CellSize(cell_size) => {
                 if let Some((w, h)) = cell_size {
-                    font_size = Some((*w, *h));
+                    font_size = Some((*w, *h).into());
                 }
                 Some(Capability::CellSize(*cell_size))
             }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use image::{DynamicImage, ImageBuffer, Rgba, imageops};
-use ratatui::{buffer::Buffer, layout::Rect};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Rect, Size},
+};
 
 use self::{
     halfblocks::Halfblocks,
@@ -28,9 +31,8 @@ pub(crate) trait ProtocolTrait: Send + Sync {
     /// Render the currently resized and encoded data to the buffer.
     fn render(&self, area: Rect, buf: &mut Buffer);
 
-    // Get the area of the image.
-    #[allow(dead_code)]
-    fn area(&self) -> Rect;
+    // Get the size of the image.
+    fn size(&self) -> Size;
 }
 
 trait StatefulProtocolTrait: ProtocolTrait {
@@ -38,7 +40,7 @@ trait StatefulProtocolTrait: ProtocolTrait {
     /// that next call for the given area does not need to redo the work.
     ///
     /// This can be done in a background thread, and the result is stored in this [StatefulProtocol].
-    fn resize_encode(&mut self, img: DynamicImage, area: Rect) -> Result<()>;
+    fn resize_encode(&mut self, img: DynamicImage, size: Size) -> Result<()>;
 }
 
 /// A fixed-size image protocol for the [crate::Image] widget.
@@ -60,14 +62,15 @@ impl Protocol {
         };
         inner.render(area, buf);
     }
-    pub fn area(&self) -> Rect {
+    // Get the size of the image.
+    pub fn size(&self) -> Size {
         let inner: &dyn ProtocolTrait = match self {
             Self::Halfblocks(halfblocks) => halfblocks,
             Self::Sixel(sixel) => sixel,
             Self::Kitty(kitty) => kitty,
             Self::ITerm2(iterm2) => iterm2,
         };
-        inner.area()
+        inner.size()
     }
 }
 
@@ -126,8 +129,8 @@ impl StatefulProtocol {
     }
 
     // Calculate the area that this image will ultimately render to, inside the given area.
-    pub fn size_for(&self, resize: Resize, area: Rect) -> Rect {
-        resize.render_area(&self.source, self.font_size, area)
+    pub fn size_for(&self, resize: Resize, size: Size) -> Size {
+        resize.render_area(&self.source, self.font_size, size)
     }
 
     pub fn protocol_type(&self) -> &StatefulProtocolType {
@@ -148,24 +151,24 @@ impl StatefulProtocol {
         self.source.background_color
     }
 
-    fn last_encoding_area(&self) -> Rect {
-        self.protocol_type.inner_trait().area()
+    fn last_encoding_area(&self) -> Size {
+        self.protocol_type.inner_trait().size()
     }
 }
 
 impl ResizeEncodeRender for StatefulProtocol {
-    fn resize_encode(&mut self, resize: &Resize, area: Rect) {
-        if area.width == 0 || area.height == 0 {
+    fn resize_encode(&mut self, resize: &Resize, size: Size) {
+        if size.width == 0 || size.height == 0 {
             return;
         }
 
-        let img = resize.resize(&self.source, self.font_size, area, self.background_color());
+        let img = resize.resize(&self.source, self.font_size, size, self.background_color());
 
         // TODO: save err in struct
         let result = self
             .protocol_type
             .inner_trait_mut()
-            .resize_encode(img, area);
+            .resize_encode(img, size);
 
         if result.is_ok() {
             self.hash = self.source.hash
@@ -178,12 +181,12 @@ impl ResizeEncodeRender for StatefulProtocol {
         self.protocol_type.inner_trait_mut().render(area, buf);
     }
 
-    fn needs_resize(&self, resize: &Resize, area: Rect) -> Option<Rect> {
+    fn needs_resize(&self, resize: &Resize, size: Size) -> Option<Size> {
         resize.needs_resize(
             &self.source,
             self.font_size,
             self.last_encoding_area(),
-            area,
+            size,
             self.source.hash != self.hash,
         )
     }
@@ -208,7 +211,7 @@ pub struct ImageSource {
     /// The original image without resizing.
     pub image: DynamicImage,
     /// The area that the [`ImageSource::image`] covers, but not necessarily fills.
-    pub desired: Rect,
+    pub desired: Size,
     /// TODO: document this; when image changes but it doesn't need a resize, force a render.
     pub hash: u64,
     /// The background color that should be used for padding or background when resizing.
@@ -245,14 +248,10 @@ impl ImageSource {
         }
     }
     /// Round an image pixel size to the nearest matching cell size, given a font size.
-    pub fn round_pixel_size_to_cells(
-        img_width: u32,
-        img_height: u32,
-        (char_width, char_height): FontSize,
-    ) -> Rect {
-        let width = (img_width as f32 / char_width as f32).ceil() as u16;
-        let height = (img_height as f32 / char_height as f32).ceil() as u16;
-        Rect::new(0, 0, width, height)
+    pub fn round_pixel_size_to_cells(img_width: u32, img_height: u32, font_size: FontSize) -> Size {
+        let width = (img_width as f32 / font_size.width as f32).ceil() as u16;
+        let height = (img_height as f32 / font_size.height as f32).ceil() as u16;
+        Size::new(width, height)
     }
 }
 

--- a/src/protocol/halfblocks.rs
+++ b/src/protocol/halfblocks.rs
@@ -14,7 +14,7 @@ compile_error!("features `chafa-static` and `chafa-dyn` are mutually exclusive")
 use image::DynamicImage;
 use ratatui::{
     buffer::{Buffer, Cell},
-    layout::Rect,
+    layout::{Rect, Size},
     style::Color,
 };
 
@@ -30,7 +30,7 @@ mod primitive;
 #[derive(Clone, Default)]
 pub struct Halfblocks {
     data: Vec<HalfBlock>,
-    area: Rect,
+    size: Size,
 }
 
 #[derive(Clone, Debug)]
@@ -56,23 +56,23 @@ impl Halfblocks {
     /// the image could be resized in relation to the font size beforehand.
     /// Also note that the font-size is probably just some arbitrary size with a 1:2 ratio when the
     /// protocol is Halfblocks, and not the actual font size of the terminal.
-    pub fn new(image: DynamicImage, area: Rect) -> Result<Self> {
-        let data = encode(&image, area);
-        Ok(Self { data, area })
+    pub fn new(image: DynamicImage, size: Size) -> Result<Self> {
+        let data = encode(&image, size);
+        Ok(Self { data, size })
     }
 
     /// Specialized render for [`crate::sliced::SlicedImage`].
     pub(crate) fn render_with_skip(&self, area: Rect, buf: &mut Buffer, skip_line_count: u16) {
-        let start = (self.area.width * skip_line_count) as usize;
-        let end = self.area.width as usize * (skip_line_count as usize + area.height as usize);
+        let start = (self.size.width * skip_line_count) as usize;
+        let end = self.size.width as usize * (skip_line_count as usize + area.height as usize);
         let hbs = &self.data[start..end];
         self.render_halfblocks(hbs, area, buf);
     }
 
     fn render_halfblocks(&self, hbs: &[HalfBlock], area: Rect, buf: &mut Buffer) {
         for (i, hb) in hbs.iter().enumerate() {
-            let x = i as u16 % self.area.width;
-            let y = i as u16 / self.area.width;
+            let x = i as u16 % self.size.width;
+            let y = i as u16 / self.size.width;
             if x >= area.width || y >= area.height {
                 continue;
             }
@@ -86,29 +86,29 @@ impl Halfblocks {
 
 // chafa-static and chafa-dyn: always use chafa (no fallback needed/possible)
 #[cfg(any(feature = "chafa-static", feature = "chafa-dyn"))]
-fn encode(img: &DynamicImage, rect: Rect) -> Vec<HalfBlock> {
-    chafa::encode(img, rect).expect("chafa is always available with compile-time linking")
+fn encode(img: &DynamicImage, size: Size) -> Vec<HalfBlock> {
+    chafa::encode(img, size).expect("chafa is always available with compile-time linking")
 }
 
 // no chafa feature: use primitive only
 #[cfg(not(any(feature = "chafa-dyn", feature = "chafa-static")))]
-fn encode(img: &DynamicImage, rect: Rect) -> Vec<HalfBlock> {
-    primitive::encode(img, rect)
+fn encode(img: &DynamicImage, size: Size) -> Vec<HalfBlock> {
+    primitive::encode(img, size)
 }
 
 impl ProtocolTrait for Halfblocks {
     fn render(&self, area: Rect, buf: &mut Buffer) {
         self.render_halfblocks(&self.data, area, buf);
     }
-    fn area(&self) -> Rect {
-        self.area
+    fn size(&self) -> Size {
+        self.size
     }
 }
 
 impl StatefulProtocolTrait for Halfblocks {
-    fn resize_encode(&mut self, img: DynamicImage, area: Rect) -> Result<()> {
-        let data = encode(&img, area);
-        *self = Halfblocks { data, area };
+    fn resize_encode(&mut self, img: DynamicImage, size: Size) -> Result<()> {
+        let data = encode(&img, size);
+        *self = Halfblocks { data, size };
         Ok(())
     }
 }
@@ -117,7 +117,7 @@ impl StatefulProtocolTrait for Halfblocks {
 mod tests {
     use image::{Rgb, RgbImage};
     use insta::assert_snapshot;
-    use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+    use ratatui::{Terminal, backend::TestBackend, layout::Size};
 
     use crate::{
         Image,
@@ -139,7 +139,7 @@ mod tests {
                     .unwrap()
                     .decode()
                     .unwrap();
-                let area = Rect::new(0, 0, 40, 20);
+                let area = Size::new(40, 20);
                 let hbs = Halfblocks::new(image, area).unwrap();
                 frame.render_widget(Image::new(&Protocol::Halfblocks(hbs)), frame.area());
             })

--- a/src/protocol/halfblocks/chafa.rs
+++ b/src/protocol/halfblocks/chafa.rs
@@ -6,7 +6,7 @@ use std::ffi::c_void;
 use std::sync::OnceLock;
 
 use image::DynamicImage;
-use ratatui::{layout::Rect, style::Color};
+use ratatui::{layout::Size, style::Color};
 
 use super::HalfBlock;
 
@@ -72,11 +72,11 @@ fn init_chafa() -> ChafaState {
 }
 
 /// Encode using chafa.
-pub fn encode(img: &DynamicImage, area: Rect) -> Option<Vec<HalfBlock>> {
+pub fn encode(img: &DynamicImage, size: Size) -> Option<Vec<HalfBlock>> {
     let chafa = CHAFA.get_or_init(init_chafa);
 
-    let width = area.width;
-    let height = area.height;
+    let width = size.width;
+    let height = size.height;
 
     unsafe {
         let config = chafa_canvas_config_new();

--- a/src/protocol/halfblocks/primitive.rs
+++ b/src/protocol/halfblocks/primitive.rs
@@ -2,7 +2,7 @@
 
 use image::DynamicImage;
 use image::imageops::FilterType;
-use ratatui::{layout::Rect, style::Color};
+use ratatui::{layout::Size, style::Color};
 
 use super::HalfBlock;
 
@@ -10,10 +10,10 @@ const HALF_UPPER: char = '▀';
 const HALF_LOWER: char = '▄';
 const SPACE: char = ' ';
 
-pub fn encode(img: &DynamicImage, rect: Rect) -> Vec<HalfBlock> {
+pub fn encode(img: &DynamicImage, size: Size) -> Vec<HalfBlock> {
     let img = img.resize_exact(
-        rect.width as u32,
-        (rect.height * 2) as u32,
+        size.width as u32,
+        (size.height * 2) as u32,
         FilterType::Triangle,
     );
 
@@ -23,12 +23,12 @@ pub fn encode(img: &DynamicImage, rect: Rect) -> Vec<HalfBlock> {
             lower: Color::Rgb(0, 0, 0),
             char: HALF_UPPER,
         };
-        (rect.width * rect.height) as usize
+        (size.width * size.height) as usize
     ];
 
     for (y, row) in img.to_rgb8().rows().enumerate() {
         for (x, pixel) in row.enumerate() {
-            let position = x + (rect.width as usize) * (y / 2);
+            let position = x + (size.width as usize) * (y / 2);
             if y % 2 == 0 {
                 data[position].upper = Color::Rgb(pixel[0], pixel[1], pixel[2]);
             } else {

--- a/src/protocol/iterm2.rs
+++ b/src/protocol/iterm2.rs
@@ -2,7 +2,10 @@
 //!
 //! Delivers the full raw png image on every render.
 use image::DynamicImage;
-use ratatui::{buffer::Buffer, layout::Rect};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Rect, Size},
+};
 use std::{cmp::min, fmt::Write, io::Cursor};
 
 use crate::{Result, picker::cap_parser::Parser};
@@ -12,29 +15,29 @@ use super::{ProtocolTrait, StatefulProtocolTrait, clear_area};
 #[derive(Clone, Default)]
 pub struct Iterm2 {
     pub data: String,
-    pub area: Rect,
+    pub size: Size,
     pub is_tmux: bool,
 }
 
 impl Iterm2 {
-    pub fn new(image: DynamicImage, area: Rect, is_tmux: bool) -> Result<Self> {
-        let png = encode(&image, area, is_tmux)?;
+    pub fn new(image: DynamicImage, size: Size, is_tmux: bool) -> Result<Self> {
+        let png = encode(&image, size, is_tmux)?;
         Ok(Self {
             data: png,
-            area,
+            size,
             is_tmux,
         })
     }
 }
 
-fn encode(img: &DynamicImage, render_area: Rect, is_tmux: bool) -> Result<String> {
+fn encode(img: &DynamicImage, size: Size, is_tmux: bool) -> Result<String> {
     let mut png: Vec<u8> = vec![];
     img.write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)?;
 
     let (start, escape, end) = Parser::escape_tmux(is_tmux);
 
-    let width = render_area.width;
-    let height = render_area.height;
+    let width = size.width;
+    let height = size.height;
     let mut seq = String::from(start);
     clear_area(&mut seq, escape, width, height);
 
@@ -55,16 +58,16 @@ fn encode(img: &DynamicImage, render_area: Rect, is_tmux: bool) -> Result<String
 
 impl ProtocolTrait for Iterm2 {
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        render(self.area, &self.data, area, buf, false)
+        render(self.size, &self.data, area, buf, false)
     }
 
-    fn area(&self) -> Rect {
-        self.area
+    fn size(&self) -> Size {
+        self.size
     }
 }
 
-fn render(rect: Rect, data: &str, area: Rect, buf: &mut Buffer, overdraw: bool) {
-    let render_area = match render_area(rect, area, overdraw) {
+fn render(size: Size, data: &str, area: Rect, buf: &mut Buffer, overdraw: bool) {
+    let render_area = match render_area(size, area, overdraw) {
         None => {
             // If we render out of area, then the buffer will attempt to write regular text (or
             // possibly other sixels) over the image.
@@ -94,28 +97,28 @@ fn render(rect: Rect, data: &str, area: Rect, buf: &mut Buffer, overdraw: bool) 
     }
 }
 
-fn render_area(rect: Rect, area: Rect, overdraw: bool) -> Option<Rect> {
+fn render_area(size: Size, area: Rect, overdraw: bool) -> Option<Rect> {
     if overdraw {
         return Some(Rect::new(
             area.x,
             area.y,
-            min(rect.width, area.width),
-            min(rect.height, area.height),
+            min(size.width, area.width),
+            min(size.height, area.height),
         ));
     }
 
-    if rect.width > area.width || rect.height > area.height {
+    if size.width > area.width || size.height > area.height {
         return None;
     }
-    Some(Rect::new(area.x, area.y, rect.width, rect.height))
+    Some(Rect::new(area.x, area.y, size.width, size.height))
 }
 
 impl StatefulProtocolTrait for Iterm2 {
-    fn resize_encode(&mut self, img: DynamicImage, area: Rect) -> Result<()> {
-        let data = encode(&img, area, self.is_tmux)?;
+    fn resize_encode(&mut self, img: DynamicImage, size: Size) -> Result<()> {
+        let data = encode(&img, size, self.is_tmux)?;
         *self = Iterm2 {
             data,
-            area,
+            size,
             ..*self
         };
         Ok(())

--- a/src/protocol/kitty.rs
+++ b/src/protocol/kitty.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::{Result, picker::cap_parser::Parser};
 use image::DynamicImage;
+use ratatui::layout::Size;
 use ratatui::{buffer::Buffer, layout::Rect};
 
 use super::{ProtocolTrait, StatefulProtocolTrait};
@@ -50,13 +51,13 @@ impl KittyProtoState {
 #[derive(Clone, Default)]
 pub struct Kitty {
     proto_state: KittyProtoState,
-    area: Rect,
+    size: Size,
 }
 
 impl Kitty {
-    pub fn new(image: DynamicImage, area: Rect, id: u32, is_tmux: bool) -> Result<Self> {
+    pub fn new(image: DynamicImage, size: Size, id: u32, is_tmux: bool) -> Result<Self> {
         let proto_state = KittyProtoState::new(&image, id, is_tmux);
-        Ok(Self { proto_state, area })
+        Ok(Self { proto_state, size })
     }
 
     /// Only for SlicedImage
@@ -66,7 +67,7 @@ impl Kitty {
 
         render(
             area,
-            self.area,
+            self.size,
             buf,
             &self.proto_state.id,
             seq,
@@ -80,18 +81,18 @@ impl ProtocolTrait for Kitty {
         // Transmit only once, track at this point via the AtomicBool in proto_state.
         let seq = self.proto_state.make_transmit();
 
-        render(area, self.area, buf, &self.proto_state.id, seq, 0);
+        render(area, self.size, buf, &self.proto_state.id, seq, 0);
     }
 
-    fn area(&self) -> Rect {
-        self.area
+    fn size(&self) -> Size {
+        self.size
     }
 }
 
 #[derive(Clone)]
 pub struct StatefulKitty {
     id: (u32, String, u16), // Full ID, Formatted color ID, ID extra part for diacritic
-    rect: Rect,
+    size: Size,
     proto_state: KittyProtoState,
     is_tmux: bool,
 }
@@ -103,7 +104,7 @@ impl StatefulKitty {
         let id_extra = u16::from(id_extra);
         StatefulKitty {
             id: (id, id_color, id_extra),
-            rect: Rect::default(),
+            size: Size::default(),
             proto_state: KittyProtoState::default(),
             is_tmux,
         }
@@ -115,17 +116,17 @@ impl ProtocolTrait for StatefulKitty {
         // Transmit only once. This is why self is mut.
         let seq = self.proto_state.make_transmit();
 
-        render(area, self.rect, buf, &self.id, seq, 0);
+        render(area, self.size, buf, &self.id, seq, 0);
     }
 
-    fn area(&self) -> Rect {
-        self.rect
+    fn size(&self) -> Size {
+        self.size
     }
 }
 
 impl StatefulProtocolTrait for StatefulKitty {
-    fn resize_encode(&mut self, img: DynamicImage, area: Rect) -> Result<()> {
-        self.rect = area;
+    fn resize_encode(&mut self, img: DynamicImage, size: Size) -> Result<()> {
+        self.size = size;
         // If resized then we must transmit again.
         self.proto_state = KittyProtoState::new(&img, self.id.0, self.is_tmux);
         Ok(())
@@ -134,13 +135,13 @@ impl StatefulProtocolTrait for StatefulKitty {
 
 fn render(
     area: Rect,
-    rect: Rect,
+    size: Size,
     buf: &mut Buffer,
     (_, id_color, id_extra): &(u32, String, u16),
     mut seq: Option<&str>,
     skip_line_count: u16,
 ) {
-    let full_width = area.width.min(rect.width);
+    let full_width = area.width.min(size.width);
     let width_usize = usize::from(full_width);
 
     let estimated_placeholder_row_size = id_color.len() +
@@ -161,7 +162,7 @@ fn render(
 
     // Clamp to effectively 297, the number of placeholders in the Kitty protocol.
     // Anything beyond would just render the something that's wrong, so skip.
-    let height = area.height.min(rect.height).min(DIACRITICS.len() as u16);
+    let height = area.height.min(size.height).min(DIACRITICS.len() as u16);
     for y in 0..height {
         // Draw each line of unicode placeholders but all into the first cell.
         // I couldn't work out actually drawing into each cell of the buffer so

--- a/src/protocol/sixel.rs
+++ b/src/protocol/sixel.rs
@@ -10,7 +10,7 @@ use icy_sixel::{EncodeOptions, sixel_encode};
 use image::DynamicImage;
 use ratatui::{
     buffer::Buffer,
-    layout::{Position, Rect},
+    layout::{Position, Rect, Size},
 };
 use std::cmp::min;
 
@@ -20,16 +20,16 @@ use crate::{Result, errors::Errors, picker::cap_parser::Parser};
 #[derive(Clone, Default)]
 pub struct Sixel {
     pub data: String,
-    pub area: Rect,
+    pub size: Size,
     pub is_tmux: bool,
 }
 
 impl Sixel {
-    pub fn new(image: DynamicImage, area: Rect, is_tmux: bool) -> Result<Self> {
-        let data = encode(&image, area, is_tmux)?;
+    pub fn new(image: DynamicImage, size: Size, is_tmux: bool) -> Result<Self> {
+        let data = encode(&image, size, is_tmux)?;
         Ok(Self {
             data,
-            area,
+            size,
             is_tmux,
         })
     }
@@ -43,14 +43,14 @@ impl Sixel {
 }
 
 // TODO: change E to sixel_rs::status::Error and map when calling
-fn encode(img: &DynamicImage, area: Rect, is_tmux: bool) -> Result<String> {
+fn encode(img: &DynamicImage, size: Size, is_tmux: bool) -> Result<String> {
     let (w, h) = (img.width(), img.height());
     let img_rgba8 = img.to_rgba8();
     let bytes = img_rgba8.as_raw();
     let (start, escape, end) = Parser::escape_tmux(is_tmux);
 
-    let width = area.width;
-    let height = area.height;
+    let width = size.width;
+    let height = size.height;
 
     let sixel_data = sixel_encode(bytes, w as usize, h as usize, &EncodeOptions::default())
         .map_err(|err| Errors::Sixel(format!("sixel encoding error: {err}")))?;
@@ -77,7 +77,7 @@ fn encode(img: &DynamicImage, area: Rect, is_tmux: bool) -> Result<String> {
 
 impl ProtocolTrait for Sixel {
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let render_area = match render_area(self.area, area, false) {
+        let render_area = match render_area(self.size, area, false) {
             None => {
                 // If we render out of area, then the buffer will attempt to write regular text (or
                 // possibly other sixels) over the image.
@@ -104,8 +104,8 @@ impl ProtocolTrait for Sixel {
         render(&self.data, render_area, buf)
     }
 
-    fn area(&self) -> Rect {
-        self.area
+    fn size(&self) -> Size {
+        self.size
     }
 }
 
@@ -126,28 +126,28 @@ fn render(data: &str, area: Rect, buf: &mut Buffer) {
     }
 }
 
-fn render_area(rect: Rect, area: Rect, overdraw: bool) -> Option<Rect> {
+fn render_area(size: Size, area: Rect, overdraw: bool) -> Option<Rect> {
     if overdraw {
         return Some(Rect::new(
             area.x,
             area.y,
-            min(rect.width, area.width),
-            min(rect.height, area.height),
+            min(size.width, area.width),
+            min(size.height, area.height),
         ));
     }
 
-    if rect.width > area.width || rect.height > area.height {
+    if size.width > area.width || size.height > area.height {
         return None;
     }
-    Some(Rect::new(area.x, area.y, rect.width, rect.height))
+    Some(Rect::new(area.x, area.y, size.width, size.height))
 }
 
 impl StatefulProtocolTrait for Sixel {
-    fn resize_encode(&mut self, img: DynamicImage, area: Rect) -> Result<()> {
-        let data = encode(&img, area, self.is_tmux)?;
+    fn resize_encode(&mut self, img: DynamicImage, size: Size) -> Result<()> {
+        let data = encode(&img, size, self.is_tmux)?;
         *self = Sixel {
             data,
-            area,
+            size,
             ..*self
         };
         Ok(())

--- a/src/sliced.rs
+++ b/src/sliced.rs
@@ -37,8 +37,8 @@ impl<'a> SlicedImage<'a> {
     /// let font_size = picker.font_size();
     /// // This example would render the image at its actual pixel size.
     /// let size = Size::new(
-    ///     dyn_img.width().div_ceil(font_size.0 as u32) as u16,
-    ///     dyn_img.height().div_ceil(font_size.1 as u32) as u16,
+    ///     dyn_img.width().div_ceil(font_size.width as u32) as u16,
+    ///     dyn_img.height().div_ceil(font_size.height as u32) as u16,
     /// );
     /// let sliced = SlicedProtocol::new(&picker, dyn_img, size)?;
     ///
@@ -79,7 +79,7 @@ impl Widget for SlicedImage<'_> {
                 } else {
                     image_area.y += self.position as u16;
                     image_area.height =
-                        (area.height - self.position.unsigned_abs()).min(kitty.area().height);
+                        (area.height - self.position.unsigned_abs()).min(kitty.size().height);
                     0
                 };
                 if image_area.height > 0 {
@@ -109,11 +109,11 @@ impl Widget for SlicedImage<'_> {
                 } else {
                     image_area.y += self.position as u16;
                     image_area.height =
-                        (area.height - self.position.unsigned_abs()).min(sixel.area().height);
+                        (area.height - self.position.unsigned_abs()).min(sixel.size().height);
                     0
                 };
                 if image_area.height > 0 {
-                    if skip_line_count == 0 && image_area.height >= sixel.area().height {
+                    if skip_line_count == 0 && image_area.height >= sixel.size().height {
                         sixel.render(image_area, buf);
                     } else {
                         sixel.render_map(image_area, buf, |data| {
@@ -134,7 +134,7 @@ impl Widget for SlicedImage<'_> {
                 } else {
                     image_area.y += self.position as u16;
                     image_area.height =
-                        (area.height - self.position.unsigned_abs()).min(halfblocks.area().height);
+                        (area.height - self.position.unsigned_abs()).min(halfblocks.size().height);
                     0
                 };
 
@@ -174,40 +174,31 @@ impl SlicedProtocol {
     ) -> Result<SlicedProtocol, Errors> {
         match picker.protocol_type() {
             ProtocolType::Kitty => {
-                let Protocol::Kitty(kitty) = picker.new_protocol(
-                    dyn_img,
-                    Rect::new(0, 0, size.width, size.height),
-                    Resize::Fit(None),
-                )?
+                let Protocol::Kitty(kitty) =
+                    picker.new_protocol(dyn_img, size, Resize::Fit(None))?
                 else {
                     unreachable!("ProtocolType::Kitty must produce Protocol::Kitty");
                 };
                 Ok(SlicedProtocol::Kitty(kitty))
             }
             ProtocolType::Sixel => {
-                let Protocol::Sixel(sixel) = picker.new_protocol(
-                    dyn_img,
-                    Rect::new(0, 0, size.width, size.height),
-                    Resize::Fit(None),
-                )?
+                let Protocol::Sixel(sixel) =
+                    picker.new_protocol(dyn_img, size, Resize::Fit(None))?
                 else {
                     unreachable!("ProtocolType::Sixel must produce Protocol::Sixel");
                 };
-                Ok(SlicedProtocol::Sixel(sixel, picker.font_size().1))
+                Ok(SlicedProtocol::Sixel(sixel, picker.font_size().height))
             }
             ProtocolType::Halfblocks => {
-                let Protocol::Halfblocks(halfblocks) = picker.new_protocol(
-                    dyn_img,
-                    Rect::new(0, 0, size.width, size.height),
-                    Resize::Fit(None),
-                )?
+                let Protocol::Halfblocks(halfblocks) =
+                    picker.new_protocol(dyn_img, size, Resize::Fit(None))?
                 else {
                     unreachable!("ProtocolType::Halfblocks must produce Protocol::Halfblocks");
                 };
                 Ok(SlicedProtocol::Halfblocks(halfblocks))
             }
             _ => {
-                let (slices, image_size) = Self::slice_rows(dyn_img, &picker.font_size(), size);
+                let (slices, image_size) = Self::slice_rows(dyn_img, picker.font_size(), size);
                 let row_count = slices.len() as u16;
                 let mut row_size = image_size;
                 row_size.height /= row_count;
@@ -231,22 +222,22 @@ impl SlicedProtocol {
     /// So this only is used for Iterm2.
     fn slice_rows(
         image: DynamicImage,
-        font_size: &FontSize,
+        font_size: FontSize,
         size: Size,
-    ) -> (Vec<DynamicImage>, Rect) {
+    ) -> (Vec<DynamicImage>, Size) {
         let image = image.resize(
-            (size.width * font_size.0).into(),
-            (size.height * font_size.1).into(),
+            (size.width * font_size.width).into(),
+            (size.height * font_size.height).into(),
             image::imageops::FilterType::Nearest,
         );
 
         let height = image.height();
         let width = image.width();
 
-        let row_count = (height as f64 / font_size.1 as f64).ceil() as u16;
+        let row_count = (height as f64 / font_size.height as f64).ceil() as u16;
         let mut rows = Vec::new();
 
-        let font_height = font_size.1 as u32;
+        let font_height = font_size.height as u32;
         for i in 0..row_count {
             let y = i as u32 * font_height;
             let row_height = font_height.min(height - y);
@@ -254,8 +245,8 @@ impl SlicedProtocol {
             rows.push(cropped);
         }
 
-        let col_count = (width as f64 / font_size.0 as f64).ceil() as u16;
-        (rows, Rect::new(0, 0, col_count, row_count))
+        let col_count = (width as f64 / font_size.width as f64).ceil() as u16;
+        (rows, Size::new(col_count, row_count))
     }
 }
 
@@ -429,13 +420,13 @@ mod tests {
         }
         let dyn_img = DynamicImage::ImageRgba8(img);
 
-        let font_size = (1, 1); // 1x1 font means 1 row per pixel row
+        let font_size = FontSize::new(1, 1); // 1x1 font means 1 row per pixel row
         let size = Size::new(4, 4);
 
-        let (rows, image_size) = SlicedProtocol::slice_rows(dyn_img, &font_size, size);
+        let (rows, image_size) = SlicedProtocol::slice_rows(dyn_img, font_size, size);
 
         assert_eq!(rows.len(), 4); // 4 rows
-        assert_eq!(image_size, Rect::new(0, 0, 4, 4));
+        assert_eq!(image_size, Size::new(4, 4));
         assert_eq!(rows[0].height(), 1);
         assert_eq!(rows[1].height(), 1);
         assert_eq!(rows[2].height(), 1);
@@ -455,13 +446,13 @@ mod tests {
         }
         let dyn_img = DynamicImage::ImageRgba8(img);
 
-        let font_size = (1, 2); // font is 2 pixels tall
+        let font_size = FontSize::new(1, 2); // font is 2 pixels tall
         let size = Size::new(4, 4); // 4 rows
 
-        let (rows, image_size) = SlicedProtocol::slice_rows(dyn_img, &font_size, size);
+        let (rows, image_size) = SlicedProtocol::slice_rows(dyn_img, font_size, size);
 
         assert_eq!(rows.len(), 4); // 4 rows
-        assert_eq!(image_size, Rect::new(0, 0, 4, 4));
+        assert_eq!(image_size, Size::new(4, 4));
         // Each row should be 2 pixels tall (font height)
         for row in &rows {
             assert_eq!(row.height(), 2);

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -10,7 +10,10 @@ use std::sync::mpsc::Sender;
 use tokio::sync::mpsc::UnboundedSender as Sender;
 
 use image::Rgba;
-use ratatui::prelude::{Buffer, Rect};
+use ratatui::{
+    layout::Size,
+    prelude::{Buffer, Rect},
+};
 
 use crate::{
     Resize, ResizeEncodeRender,
@@ -22,13 +25,13 @@ use crate::{
 pub struct ResizeRequest {
     protocol: StatefulProtocol,
     resize: Resize,
-    area: Rect,
+    size: Size,
     id: u64,
 }
 
 impl ResizeRequest {
     pub fn resize_encode(mut self) -> Result<ResizeResponse, Errors> {
-        self.protocol.resize_encode(&self.resize, self.area);
+        self.protocol.resize_encode(&self.resize, self.size);
         self.protocol
             .last_encoding_result()
             .expect("The resize has just been performed")?;
@@ -92,10 +95,10 @@ impl ThreadProtocol {
         equal
     }
 
-    pub fn size_for(&self, resize: Resize, area: Rect) -> Option<Rect> {
+    pub fn size_for(&self, resize: Resize, size: Size) -> Option<Size> {
         self.inner
             .as_ref()
-            .map(|protocol| protocol.size_for(resize, area))
+            .map(|protocol| protocol.size_for(resize, size))
     }
 
     fn increment_id(&mut self) {
@@ -104,20 +107,20 @@ impl ThreadProtocol {
 }
 
 impl ResizeEncodeRender for ThreadProtocol {
-    fn needs_resize(&self, resize: &Resize, area: Rect) -> Option<Rect> {
+    fn needs_resize(&self, resize: &Resize, size: Size) -> Option<Size> {
         self.inner
             .as_ref()
-            .and_then(|protocol| protocol.needs_resize(resize, area))
+            .and_then(|protocol| protocol.needs_resize(resize, size))
     }
 
     /// Senda a `ResizeRequest` through the channel if there already isn't a pending `ResizeRequest`
-    fn resize_encode(&mut self, resize: &Resize, area: Rect) {
+    fn resize_encode(&mut self, resize: &Resize, size: Size) {
         let _ = self.inner.take().map(|protocol| {
             self.increment_id();
             _ = self.tx.send(ResizeRequest {
                 protocol,
                 resize: resize.clone(),
-                area,
+                size,
                 id: self.id,
             });
         });


### PR DESCRIPTION
A long due refactor. Many variables/fields in ratatui-image were `Rect` for no good reason, when they should have been `Size`.

This makes a lot of the code more readable.