### PR TITLE
check for ascii control characters returned by `chafa_canvas_get_char_at()`

### DIFF
--- a/src/protocol/halfblocks/chafa.rs
+++ b/src/protocol/halfblocks/chafa.rs
@@ -102,9 +102,10 @@ pub fn encode(img: &DynamicImage, size: Size) -> Option<Vec<HalfBlock>> {
         for y in 0..height {
             for x in 0..width {
                 let c = chafa_canvas_get_char_at(canvas, x as i32, y as i32);
-                let symbol = char::from_u32(c)
-                    .filter(|c| !c.is_ascii_control())
-                    .unwrap_or(' ');
+                // chafa adds a trailing '\0' after characters rendered as two cells wide,
+                // but ratatui panics when rendering control characters.
+                // filtering them out as spaces should be safe.
+                let symbol = char::from_u32(c).filter(|c| *c != '\0').unwrap_or(' ');
 
                 let mut fg_color: i32 = 0;
                 let mut bg_color: i32 = 0;

--- a/src/protocol/halfblocks/chafa.rs
+++ b/src/protocol/halfblocks/chafa.rs
@@ -102,7 +102,9 @@ pub fn encode(img: &DynamicImage, size: Size) -> Option<Vec<HalfBlock>> {
         for y in 0..height {
             for x in 0..width {
                 let c = chafa_canvas_get_char_at(canvas, x as i32, y as i32);
-                let symbol = char::from_u32(c).unwrap_or(' ');
+                let symbol = char::from_u32(c)
+                    .filter(|c| !c.is_ascii_control())
+                    .unwrap_or(' ');
 
                 let mut fg_color: i32 = 0;
                 let mut bg_color: i32 = 0;


### PR DESCRIPTION
this works to fix a bug with a specific image i had where `chafa_canvas_get_char_at()` returns 0 and eventually ratatui panics buffer/cell_width:36, but i dont think this is the source of the bug because `chafa_canvas_get_char_at()` returns 0 in [some error cases](https://github.com/hpjansson/chafa/blob/61a9ae47415fd9c26c22e86854217b6e66c130e2/chafa/chafa-canvas.c#L1049). unless canvas->config is not what ratatui-image thinks it is it seems that canvas->refs is 0 i think? i havent checked what causes that