### PR TITLE
use ioctl font-size and env hints when the capability query gets no response

### DIFF
--- a/src/picker.rs
+++ b/src/picker.rs
@@ -107,17 +107,6 @@ impl Picker {
         // Detect tmux, and only if positive then take some risky guess for iTerm2 support.
         let (is_tmux, tmux_proto) = detect_tmux_and_outer_protocol_from_env();
 
-        static DEFAULT_PICKER: Picker = Picker {
-            // This is completely arbitrary. For halfblocks, it doesn't have to be precise
-            // since we're not rendering pixels. It should be roughly 1:2 ratio, and some
-            // reasonable size.
-            font_size: FontSize::new(10, 20),
-            background_color: None,
-            protocol_type: ProtocolType::Halfblocks,
-            is_tmux: false,
-            capabilities: Vec::new(),
-        };
-
         let mut options_with_blacklist = options;
         let is_wezterm = env::var("WEZTERM_EXECUTABLE").is_ok_and(|s| !s.is_empty());
         let is_konsole = env::var("KONSOLE_VERSION").is_ok_and(|s| !s.is_empty());
@@ -155,10 +144,16 @@ impl Picker {
                     Ok(p)
                 }
             }
+            // The terminal did not answer the query, but it may still be possible to figure out
+            // the font-size with an ioctl, and env vars may still hint at iTerm2 support. This
+            // happens for example on Windows ConPTY, which does not reliably deliver the
+            // responses to the child process.
             Err(Errors::NoCap | Errors::NoStdinResponse | Errors::NoFontSize) => {
-                let mut p = DEFAULT_PICKER.clone();
-                p.is_tmux = is_tmux;
-                Ok(p)
+                Ok(fallback_picker(
+                    is_tmux,
+                    tmux_proto.or_else(iterm2_from_env),
+                    font_size_fallback(),
+                ))
             }
             Err(err) => Err(err),
         }
@@ -291,6 +286,35 @@ impl Picker {
         };
         StatefulProtocol::new(image, self.font_size, self.background_color, protocol_type)
     }
+}
+
+static DEFAULT_PICKER: Picker = Picker {
+    // This is completely arbitrary. For halfblocks, it doesn't have to be precise
+    // since we're not rendering pixels. It should be roughly 1:2 ratio, and some
+    // reasonable size.
+    font_size: FontSize::new(10, 20),
+    background_color: None,
+    protocol_type: ProtocolType::Halfblocks,
+    is_tmux: false,
+    capabilities: Vec::new(),
+};
+
+/// Build a picker from whatever could be detected without the terminal answering the query.
+///
+/// A protocol other than halfblocks can only render meaningfully with an actual font-size, so
+/// without one the `protocol_type` hint is discarded, just like on the query's success path.
+fn fallback_picker(
+    is_tmux: bool,
+    protocol_type: Option<ProtocolType>,
+    font_size: Option<FontSize>,
+) -> Picker {
+    let mut picker = DEFAULT_PICKER.clone();
+    picker.is_tmux = is_tmux;
+    if let Some(font_size) = font_size {
+        picker.font_size = font_size;
+        picker.protocol_type = protocol_type.unwrap_or(ProtocolType::Halfblocks);
+    }
+    picker
 }
 
 fn detect_tmux_and_outer_protocol_from_env() -> (bool, Option<ProtocolType>) {
@@ -601,9 +625,12 @@ fn query_with_timeout(
 mod tests {
     use std::assert_eq;
 
-    use crate::picker::{Capability, Picker, ProtocolType};
+    use crate::{
+        FontSize,
+        picker::{Capability, Picker, ProtocolType},
+    };
 
-    use super::{cap_parser::Response, interpret_parser_responses};
+    use super::{cap_parser::Response, fallback_picker, interpret_parser_responses};
 
     #[test]
     fn test_cycle_protocol() {
@@ -621,6 +648,30 @@ mod tests {
     #[test]
     fn test_from_query_stdio_no_hang() {
         let _ = Picker::from_query_stdio();
+    }
+
+    #[test]
+    fn test_fallback_picker() {
+        // The terminal did not answer, but the font-size is known from the ioctl fallback and
+        // some env var hinted at iTerm2 support: use it instead of halfblocks.
+        let picker = fallback_picker(
+            false,
+            Some(ProtocolType::Iterm2),
+            Some(FontSize::new(8, 16)),
+        );
+        assert_eq!(picker.protocol_type(), ProtocolType::Iterm2);
+        assert_eq!(
+            (picker.font_size().width, picker.font_size().height),
+            (8, 16)
+        );
+
+        // Without a font-size, no other protocol can be rendered meaningfully.
+        let picker = fallback_picker(false, Some(ProtocolType::Iterm2), None);
+        assert_eq!(picker.protocol_type(), ProtocolType::Halfblocks);
+
+        // Without a hint, stay on halfblocks.
+        let picker = fallback_picker(false, None, Some(FontSize::new(8, 16)));
+        assert_eq!(picker.protocol_type(), ProtocolType::Halfblocks);
     }
 
     #[test]


### PR DESCRIPTION
Refs #164.

## The problem

`from_query_stdio_with_options` throws away two things it already knows when the terminal does not answer the capability query.

On the `Ok(_)` arm the font-size falls back to the `TIOCGWINSZ` ioctl (`font_size = font_size.or_else(font_size_fallback)` in `interpret_parser_responses`) and the protocol falls back to `tmux_proto` / `iterm2_from_env()`. On the `Err(NoCap | NoStdinResponse | NoFontSize)` arm neither happens — it returns the hardcoded `DEFAULT_PICKER`, i.e. `Halfblocks` with the arbitrary 10x20 font-size, no matter what the tty or the environment says.

So a terminal that never gets the query response back — Windows ConPTY being the reported case, but also anything that swallows the DA1/XTWINOPS replies — silently renders halfblocks even when `TERM_PROGRAM`/`ITERM_SESSION_ID`/`WEZTERM_EXECUTABLE` say iTerm2 is supported *and* the tty reports a cell size.

Reproducer, on a pty where nothing answers the query (so the 2s timeout is always hit) and whose winsize reports 100x40 cells / 800x800 px, i.e. a 8x20 cell:

```
$ TERM_PROGRAM=iTerm.app <pty, cell size 8x20, no responder> ./probe
protocol=Halfblocks font_size=FontSize { width: 10, height: 20 }
```

## The fix

Mirror the `Ok(_)` arm: consult `tmux_proto.or_else(iterm2_from_env)` and `font_size_fallback()` on the error arm too, via a small `fallback_picker()` helper.

The helper deliberately keeps the invariant the success path already has: **a protocol other than halfblocks is only selected when an actual font-size is known.** `Iterm2` sends `width=<px>;height=<px>`, so with a made-up cell size the image is scaled to the wrong number of cells — that is exactly why the `Ok(_)` arm also drops back to `DEFAULT_PICKER` when `font_size` is `None`. Without a font-size this change is a no-op.

Same reproducer after the change:

```
$ TERM_PROGRAM=iTerm.app <pty, cell size 8x20, no responder> ./probe
protocol=Iterm2 font_size=FontSize { width: 8, height: 20 }
```

and with the pixel fields of the winsize zeroed, i.e. no font-size available anywhere, it stays on halfblocks exactly as before:

```
$ TERM_PROGRAM=iTerm.app <pty, no pixel size, no responder> ./probe
protocol=Halfblocks font_size=FontSize { width: 10, height: 20 }
```

The success path is untouched — with a responder attached the result is byte-identical before and after:

```
protocol=Sixel font_size=FontSize { width: 8, height: 20 } caps=[CellSize(Some((8, 20))), Sixel]
```

## About the workaround in #164

Bumping `QueryStdioOptions::timeout` does help when the response is merely slow, but on ConPTY the responses are frequently not delivered at all, so a longer timeout only makes startup slower before landing on the same halfblocks fallback. You also mentioned looking for the cell size "some other way: `ioctl`" — that is `font_size_fallback()`, which already exists; it was just unreachable from this arm.

To be upfront: this does **not** fully close #164 on native Windows, because `font_size_fallback()` is `None` there and the invariant above then keeps halfblocks. It fixes the same defect everywhere the tty does report a cell size (the reporter also hits this from WSL2, and any Unix terminal whose query replies get swallowed is affected). A Windows cell-size source looks like separate work.

## Test

`fallback_picker()` is a pure function, so `test_fallback_picker` covers the three cases without touching stdio or mutating env vars (which would race with `test_from_query_stdio_no_hang`). Reverting the helper body to the previous behaviour fails it with `left: Halfblocks, right: Iterm2`.

## Not changed

- The `Ok(_)` arm, including the fact that it drops the queried capabilities when no font-size was found.
- No CHANGELOG entry, since release-plz generates it.
- `DEFAULT_PICKER` only moved from a function-local `static` to a module-level one so the helper can use it; its value is unchanged.

This does not conflict with #159, which touches the blacklist a few lines above.
